### PR TITLE
Don't use zip_release

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,4 @@
 {
   "name": "Samsung Soundbar",
-  "filename": "samsung_soundbar.zip",
-  "render_readme": true,
-  "zip_release": true
+  "render_readme": true
 }


### PR DESCRIPTION
I noticed the 0.3.0b2 release has a faulty zip asset.
There doesn't seem to be a point in using this format anyway.
Is there anything I missed? Do you add anything in there that's not in the repo?