### PR TITLE
Trigger `ConfigEntryNotReady` exception when the update during setup fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.1] Let HomeAssistant schedule failing setup of integration
+
+### Added
+
+- Add a `try / catch` mechanism to the first update of the client while setup and throw a
+  `ConfigEntryNotReady` exception when the update fails
+
 ## [0.3.0] Icons and Chore
 
 ### Added

--- a/custom_components/samsung_soundbar/__init__.py
+++ b/custom_components/samsung_soundbar/__init__.py
@@ -1,7 +1,9 @@
 import logging
 
+from aiohttp import ClientResponseError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import DOMAIN, HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from pysmartthings import SmartThings
 
@@ -49,7 +51,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data.get(CONF_ENTRY_MAX_VOLUME),
             entry.data.get(CONF_ENTRY_DEVICE_NAME),
         )
-        await soundbar_device.update()
+        try:
+            await soundbar_device.update()
+        except ClientResponseError as excp:
+            raise ConfigEntryNotReady("An error occurred while setting up the soundbar device. "
+                                      "Please recheck whether the device has power or is connected to the internet.")\
+                from excp
         domain_config.devices[entry.data.get(CONF_ENTRY_DEVICE_ID)] = DeviceConfig(
             entry.data, soundbar_device
         )

--- a/custom_components/samsung_soundbar/manifest.json
+++ b/custom_components/samsung_soundbar/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/samuelspagl/ha_samsung_soundbar/issues",
   "requirements": ["pysmartthings"],
-  "version": "0.3.0"
+  "version": "0.3.1"
 }


### PR DESCRIPTION
# 🐛 Trigger `ConfigEntryNotReady` exception when the update during setup fails

This PR is just a minor bugfix that should advise HomeAssistant to retry setting up the integration when the first `update` process of the device fails.

### Changelog

#### Added

- Add a `try / catch` mechanism to the first update of the client while setup and throw a
  `ConfigEntryNotReady` exception when the update fails