### PR TITLE
Implement async setup and unload for Soundbar device

### DIFF
--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,0 +1,102 @@
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import DOMAIN, HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from pysmartthings import SmartThings
+
+from .api_extension.SoundbarDevice import SoundbarDevice
+from .const import (
+    CONF_ENTRY_API_KEY,
+    CONF_ENTRY_DEVICE_ID,
+    CONF_ENTRY_DEVICE_NAME,
+    CONF_ENTRY_MAX_VOLUME,
+    CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES,
+    CONF_ENTRY_SETTINGS_EQ_SELECTOR,
+    CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR,
+    CONF_ENTRY_SETTINGS_WOOFER_NUMBER,
+    DOMAIN,
+    SUPPORTED_DOMAINS,
+)
+from .models import DeviceConfig, SoundbarConfig
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = ["media_player", "switch", "image", "number", "select", "sensor"]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up component from a config entry, config_entry contains data from config entry database."""
+    # store shell object
+
+    _LOGGER.info(f"[{DOMAIN}] Starting to setup a ConfigEntry")
+    _LOGGER.debug(
+        f"[{DOMAIN}] Setting up ConfigEntry with the following data: {entry.data}"
+    )
+    if not DOMAIN in hass.data:
+        _LOGGER.debug(f"[{DOMAIN}] Domain not found in hass.data setting default")
+        hass.data[DOMAIN] = SoundbarConfig(
+            SmartThings(
+                async_get_clientsession(hass), entry.data.get(CONF_ENTRY_API_KEY)
+            ),
+            {},
+        )
+
+    domain_config: SoundbarConfig = hass.data[DOMAIN]
+    _LOGGER.debug(f"[{DOMAIN}] Retrieved Domain Config: {domain_config}")
+
+    if not entry.data.get(CONF_ENTRY_DEVICE_ID) in domain_config.devices:
+        _LOGGER.info(f"[{DOMAIN}] Setting up new Soundbar device")
+        _LOGGER.debug(
+            f"[{DOMAIN}] DeviceId: {entry.data.get(CONF_ENTRY_DEVICE_ID)} not found in domain_config, setting up new device."
+        )
+        smart_things_device = await domain_config.api.device(
+            entry.data.get(CONF_ENTRY_DEVICE_ID)
+        )
+        session = async_get_clientsession(hass)
+        soundbar_device = SoundbarDevice(
+            smart_things_device,
+            session,
+            entry.data.get(CONF_ENTRY_MAX_VOLUME),
+            entry.data.get(CONF_ENTRY_DEVICE_NAME),
+            enable_eq=entry.data.get(CONF_ENTRY_SETTINGS_EQ_SELECTOR),
+            enable_advanced_audio=entry.data.get(
+                CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES
+            ),
+            enable_soundmode=entry.data.get(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR),
+            enable_woofer=entry.data.get(CONF_ENTRY_SETTINGS_WOOFER_NUMBER),
+        )
+        await soundbar_device.update()
+        domain_config.devices[entry.data.get(CONF_ENTRY_DEVICE_ID)] = DeviceConfig(
+            entry.data, soundbar_device
+        )
+        _LOGGER.info(f"[{DOMAIN}] Successfully initialized new Soundbar device")
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    domain_data = hass.data.get(DOMAIN)
+    if not domain_data:
+        # nada pra fazer
+        return True
+
+    device_id = entry.data.get(CONF_ENTRY_DEVICE_ID)
+    # remove com segurança (não lança KeyError se não existir)
+    domain_data.devices.pop(device_id, None)
+
+    # tente descarregar as plataformas registradas para essa entry
+    # substitua PLATFORMS pelo nome da lista usada no seu __init__.py (ex: PLATFORMS = ["media_player"])
+    try:
+        unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    except Exception:
+        unload_ok = False
+
+    # se não houver mais devices, limpa o domínio inteiro
+    if not domain_data.devices:
+        hass.data.pop(DOMAIN, None)
+
+    return unload_ok
+


### PR DESCRIPTION
When unloading a config entry (async_unload_entry), the integration used del domain_data.devices[device_id], which raised a KeyError if the device no longer existed in the internal dictionary.

The fix replaces this with a safe pop(..., None) call, preventing exceptions and ensuring the unload process completes successfully.

A cleanup step was also added to remove the domain from hass.data when no devices remain.

Change summary:

Prevented KeyError during integration unload
Added safe cleanup for hass.data when all devices are removed Improved stability during restart or entry removal.