### PR TITLE
Fix HA DEVICE_CLASS_SPEAKER import + OCF/Q990D improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 .DS_store
+.DS_Store
+._*
 
 config
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.5.0] Compatibility + Config Flow + OCF Improvements
+
+### Fixed
+
+- Added Home Assistant compatibility fallback for `DEVICE_CLASS_SPEAKER` to prevent import errors on newer HA versions
+- Fixed config flow handler issues and improved setup stability for modern Home Assistant builds
+- Improved woofer state update and mute handling logic
+
+### Added
+
+- Added raw execute / OCF service calls for advanced Samsung capability control
+- Added coordinator-based updates and additional SamsungVD entity exposure
+- Added `services.yaml` documentation entries for newly exposed services
+
+### Changed
+
+- Replaced `pysmartthings` dependency path with direct SmartThings REST client handling
+- Improved OCF soundbar compatibility (including better behavior for newer Q-series models)
+- Reduced polling pressure and improved handling for empty execute status payloads
+- Config flow now defaults advanced toggles to off and redacts token values in errors/logs
+
 ## [0.4.1] Media Mystique: The Great Data Disappearing Act!
 
 ### Fixed

--- a/custom_components/samsung_soundbar/__init__.py
+++ b/custom_components/samsung_soundbar/__init__.py
@@ -56,6 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         soundbar_device = SoundbarDevice(
             smart_things_device,
             session,
+            entry.data.get(CONF_ENTRY_API_KEY),
             entry.data.get(CONF_ENTRY_MAX_VOLUME),
             entry.data.get(CONF_ENTRY_DEVICE_NAME),
             enable_eq=entry.data.get(CONF_ENTRY_SETTINGS_EQ_SELECTOR),

--- a/custom_components/samsung_soundbar/__init__.py
+++ b/custom_components/samsung_soundbar/__init__.py
@@ -2,11 +2,10 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from pysmartthings import SmartThings
 
 from .api_extension.SoundbarDevice import SoundbarDevice
 from .coordinator import SoundbarCoordinator
+from .smartthings_api import SmartThingsApi
 from .const import (
     CONF_ENTRY_API_KEY,
     CONF_ENTRY_DEVICE_ID,
@@ -35,9 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not DOMAIN in hass.data:
         _LOGGER.debug(f"[{DOMAIN}] Domain not found in hass.data setting default")
         hass.data[DOMAIN] = SoundbarConfig(
-            SmartThings(
-                async_get_clientsession(hass), entry.data.get(CONF_ENTRY_API_KEY)
-            ),
+            SmartThingsApi(hass, entry.data.get(CONF_ENTRY_API_KEY)),
             {},
         )
 
@@ -49,16 +46,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.debug(
             f"[{DOMAIN}] DeviceId: {entry.data.get(CONF_ENTRY_DEVICE_ID)} not found in domain_config, setting up new device."
         )
-        smart_things_device = await domain_config.api.device(
-            entry.data.get(CONF_ENTRY_DEVICE_ID)
-        )
-        session = async_get_clientsession(hass)
+        device_id = entry.data.get(CONF_ENTRY_DEVICE_ID)
+        await domain_config.api.get_device(device_id)
         soundbar_device = SoundbarDevice(
-            smart_things_device,
-            session,
             entry.data.get(CONF_ENTRY_API_KEY),
-            entry.data.get(CONF_ENTRY_MAX_VOLUME),
-            entry.data.get(CONF_ENTRY_DEVICE_NAME),
+            domain_config.api,
+            device_id=device_id,
+            max_volume=entry.data.get(CONF_ENTRY_MAX_VOLUME),
+            device_name=entry.data.get(CONF_ENTRY_DEVICE_NAME),
             enable_eq=entry.data.get(CONF_ENTRY_SETTINGS_EQ_SELECTOR),
             enable_advanced_audio=entry.data.get(
                 CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES

--- a/custom_components/samsung_soundbar/__init__.py
+++ b/custom_components/samsung_soundbar/__init__.py
@@ -28,9 +28,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # store shell object
 
     _LOGGER.info(f"[{DOMAIN}] Starting to setup a ConfigEntry")
-    _LOGGER.debug(
-        f"[{DOMAIN}] Setting up ConfigEntry with the following data: {entry.data}"
-    )
+    # Never log secrets (SmartThings personal access token lives in entry.data).
+    if _LOGGER.isEnabledFor(logging.DEBUG):
+        redacted = dict(entry.data)
+        if CONF_ENTRY_API_KEY in redacted:
+            redacted[CONF_ENTRY_API_KEY] = "***REDACTED***"
+        _LOGGER.debug(f"[{DOMAIN}] Setting up ConfigEntry with the following data: {redacted}")
     if not DOMAIN in hass.data:
         _LOGGER.debug(f"[{DOMAIN}] Domain not found in hass.data setting default")
         hass.data[DOMAIN] = SoundbarConfig(

--- a/custom_components/samsung_soundbar/__init__.py
+++ b/custom_components/samsung_soundbar/__init__.py
@@ -1,11 +1,12 @@
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import DOMAIN, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from pysmartthings import SmartThings
 
 from .api_extension.SoundbarDevice import SoundbarDevice
+from .coordinator import SoundbarCoordinator
 from .const import (
     CONF_ENTRY_API_KEY,
     CONF_ENTRY_DEVICE_ID,
@@ -16,13 +17,11 @@ from .const import (
     CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR,
     CONF_ENTRY_SETTINGS_WOOFER_NUMBER,
     DOMAIN,
-    SUPPORTED_DOMAINS,
+    PLATFORMS,
 )
 from .models import DeviceConfig, SoundbarConfig
 
 _LOGGER = logging.getLogger(__name__)
-
-PLATFORMS = ["media_player", "switch", "image", "number", "select", "sensor"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -66,9 +65,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             enable_soundmode=entry.data.get(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR),
             enable_woofer=entry.data.get(CONF_ENTRY_SETTINGS_WOOFER_NUMBER),
         )
-        await soundbar_device.update()
+        coordinator = SoundbarCoordinator(hass, soundbar_device)
+        await coordinator.async_config_entry_first_refresh()
+
         domain_config.devices[entry.data.get(CONF_ENTRY_DEVICE_ID)] = DeviceConfig(
-            entry.data, soundbar_device
+            entry.data, soundbar_device, coordinator
         )
         _LOGGER.info(f"[{DOMAIN}] Successfully initialized new Soundbar device")
 

--- a/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
+++ b/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
@@ -4,7 +4,7 @@ import json
 import logging
 from urllib.parse import quote
 
-from pysmartthings import DeviceEntity
+from typing import Any
 
 from .const import SpeakerIdentifier, RearSpeakerMode
 from ..const import DOMAIN
@@ -15,8 +15,9 @@ log = logging.getLogger(__name__)
 class SoundbarDevice:
     def __init__(
             self,
-            device: DeviceEntity,
+            device: Any,
             session,
+            api_key: str,
             max_volume: int,
             device_name: str,
             enable_eq: bool = False,
@@ -26,7 +27,8 @@ class SoundbarDevice:
     ):
         self.device = device
         self._device_id = self.device.device_id
-        self._api_key = self.device._api.token
+        # Don't depend on private pysmartthings internals; pass the token from the config entry.
+        self._api_key = api_key
         self.__session = session
         self.__device_name = device_name
 

--- a/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
+++ b/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
@@ -1,78 +1,122 @@
+from __future__ import annotations
+
 import asyncio
-import datetime
+import datetime as dt
 import json
 import logging
-from urllib.parse import quote
-
 from typing import Any
 
-from .const import SpeakerIdentifier, RearSpeakerMode
 from ..const import DOMAIN
+from ..smartthings_api import SmartThingsApi
+from .const import RearSpeakerMode, SpeakerIdentifier
 
-log = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 class SoundbarDevice:
+    """
+    SmartThings Soundbar wrapper using the raw SmartThings REST API.
+
+    This avoids depending on `pysmartthings`, which has had breaking API/exports
+    across versions (and caused config flow/runtime import errors).
+    """
+
     def __init__(
-            self,
-            device: Any,
-            session,
-            api_key: str,
-            max_volume: int,
-            device_name: str,
-            enable_eq: bool = False,
-            enable_soundmode: bool = False,
-            enable_advanced_audio: bool = False,
-            enable_woofer: bool = False,
-    ):
-        self.device = device
-        self._device_id = self.device.device_id
-        # Don't depend on private pysmartthings internals; pass the token from the config entry.
+        self,
+        api_key: str,
+        api: SmartThingsApi,
+        *,
+        device_id: str,
+        max_volume: int,
+        device_name: str,
+        enable_eq: bool = False,
+        enable_soundmode: bool = False,
+        enable_advanced_audio: bool = False,
+        enable_woofer: bool = False,
+    ) -> None:
+        self._api = api
         self._api_key = api_key
-        self.__session = session
+        self._device_id = device_id
+
         self.__device_name = device_name
+        self.__max_volume = int(max_volume)
 
-        self.__enable_soundmode = enable_soundmode
-        self.__supported_soundmodes = []
-        self.__active_soundmode = ""
+        # Feature flags (UI toggles)
+        self.__enable_eq = bool(enable_eq)
+        self.__enable_soundmode = bool(enable_soundmode)
+        self.__enable_advanced_audio = bool(enable_advanced_audio)
+        self.__enable_woofer = bool(enable_woofer)
 
-        self.__enable_woofer = enable_woofer
-        self.__woofer_level = 0
-        self.__woofer_connection = ""
+        # Cached REST payloads
+        self._device: dict[str, Any] | None = None
+        self._status: dict[str, Any] | None = None
+        self._main: dict[str, Any] = {}
 
-        self.__enable_eq = enable_eq
-        self.__active_eq_preset = ""
-        self.__supported_eq_presets = []
-        self.__eq_action = ""
-        self.__eq_bands = []
+        # Derived state
+        self.__supported_soundmodes: list[str] = []
+        self.__active_soundmode: str | None = None
+        self.__woofer_level: int | None = None
+        self.__woofer_connection: str | None = None
+        self.__active_eq_preset: str | None = None
+        self.__supported_eq_presets: list[str] = []
+        self.__eq_action: Any = None
+        self.__eq_bands: Any = None
+        self.__night_mode: int | None = None
+        self.__bass_mode: int | None = None
+        self.__voice_amplifier: int | None = None
 
-        self.__enable_advanced_audio = enable_advanced_audio
-        self.__voice_amplifier = 0
-        self.__night_mode = 0
-        self.__bass_mode = 0
+        # Media metadata (often not available on OCF models; keep optional)
+        self.__media_title: str | None = None
+        self.__media_artist: str | None = None
+        self.__media_cover_url: str | None = None
+        self.__media_cover_url_update_time: dt.datetime | None = None
 
-        self.__media_title = ""
-        self.__media_artist = ""
-        self.__media_cover_url = ""
-        self.__media_cover_url_update_time: datetime.datetime | None = None
-        self.__old_media_title = ""
-
-        self.__max_volume = max_volume
+        # execute/status is rate limited and for some OCF models returns null permanently.
         self.__execute_status_supported: bool | None = None
 
-    def _attr(self, name: str):
-        """Best-effort attribute lookup from SmartThings status."""
-        try:
-            attr = self.device.status.attributes.get(name)
-        except Exception:
-            attr = None
-        return attr.value if attr is not None else None
+    # ------------ REST helpers ------------
 
-    async def update(self):
-        await self.device.status.refresh()
+    async def command(self, capability: str, command: str, arguments: list[Any] | None = None) -> None:
+        cmd: dict[str, Any] = {
+            "component": "main",
+            "capability": capability,
+            "command": command,
+        }
+        if arguments is not None:
+            cmd["arguments"] = arguments
+        await self._api.send_commands(self._device_id, [cmd])
 
-        await self._update_media()
+    def _cap(self, capability: str) -> dict[str, Any]:
+        v = self._main.get(capability)
+        return v if isinstance(v, dict) else {}
 
+    def _cap_attr(self, capability: str, attr: str) -> Any:
+        cap = self._cap(capability)
+        node = cap.get(attr)
+        if isinstance(node, dict):
+            return node.get("value")
+        return None
+
+    def _attr(self, name: str) -> Any:
+        # Best-effort search across all capabilities in main.
+        for cap in self._main.values():
+            if not isinstance(cap, dict):
+                continue
+            node = cap.get(name)
+            if isinstance(node, dict) and "value" in node:
+                return node.get("value")
+        return None
+
+    async def update(self) -> None:
+        self._device = await self._api.get_device(self._device_id)
+        self._status = await self._api.get_status(self._device_id)
+        self._main = (
+            (self._status.get("components") or {}).get("main") or {}
+            if isinstance(self._status, dict)
+            else {}
+        )
+
+        # Cache fields that we expose as properties
         if self.__enable_soundmode:
             await self._update_soundmode()
         if self.__enable_advanced_audio:
@@ -82,165 +126,53 @@ class SoundbarDevice:
         if self.__enable_eq:
             await self._update_equalizer()
 
-    async def _update_media(self):
-        if "audioTrackData" in self.device.status._attributes:
-            self.__media_artist = self.device.status._attributes["audioTrackData"].value[
-                "artist"
-            ]
-            self.__media_title = self.device.status._attributes["audioTrackData"].value[
-                "title"
-            ]
-            if self.__media_title != self.__old_media_title:
-                self.__old_media_title = self.__media_title
-                self.__media_cover_url_update_time = datetime.datetime.now()
-                self.__media_cover_url = await self.get_song_title_artwork(
-                    self.__media_artist, self.__media_title
-                )
-
-    async def _update_soundmode(self):
-        if self.__execute_status_supported is False:
-            return
-        await self.update_execution_data(["/sec/networkaudio/soundmode"])
-        await asyncio.sleep(1)
-        payload = await self.get_execute_status()
-        retry = 0
-        # execute/status is rate limited and may be empty/null for some devices (e.g. newer OCF models).
-        while (
-            "x.com.samsung.networkaudio.supportedSoundmode" not in payload
-            and retry < 3
-        ):
-            await asyncio.sleep(2)
-            payload = await self.get_execute_status()
-            retry += 1
-        if "x.com.samsung.networkaudio.supportedSoundmode" not in payload:
-            log.debug(f"[{DOMAIN}] execute/status did not return soundmode payload (device may not support it).")
-            return
-
-        self.__supported_soundmodes = payload[
-            "x.com.samsung.networkaudio.supportedSoundmode"
-        ]
-        self.__active_soundmode = payload["x.com.samsung.networkaudio.soundmode"]
-
-    async def _update_woofer(self):
-        if self.__execute_status_supported is False:
-            return
-        await self.update_execution_data(["/sec/networkaudio/woofer"])
-        await asyncio.sleep(0.1)
-        payload = await self.get_execute_status()
-        retry = 0
-        while "x.com.samsung.networkaudio.woofer" not in payload and retry < 3:
-            await asyncio.sleep(1)
-            payload = await self.get_execute_status()
-            retry += 1
-        if "x.com.samsung.networkaudio.woofer" not in payload:
-            log.debug(f"[{DOMAIN}] execute/status did not return woofer payload (device may not support it).")
-            return
-        self.__woofer_level = payload["x.com.samsung.networkaudio.woofer"]
-        self.__woofer_connection = payload["x.com.samsung.networkaudio.connection"]
-
-    async def _update_equalizer(self):
-        if self.__execute_status_supported is False:
-            return
-        await self.update_execution_data(["/sec/networkaudio/eq"])
-        await asyncio.sleep(0.1)
-        payload = await self.get_execute_status()
-        retry = 0
-        while "x.com.samsung.networkaudio.EQname" not in payload and retry < 3:
-            await asyncio.sleep(1)
-            payload = await self.get_execute_status()
-            retry += 1
-        if "x.com.samsung.networkaudio.EQname" not in payload:
-            log.debug(f"[{DOMAIN}] execute/status did not return equalizer payload (device may not support it).")
-            return
-        self.__active_eq_preset = payload["x.com.samsung.networkaudio.EQname"]
-        self.__supported_eq_presets = payload[
-            "x.com.samsung.networkaudio.supportedList"
-        ]
-        self.__eq_action = payload["x.com.samsung.networkaudio.action"]
-        self.__eq_bands = payload["x.com.samsung.networkaudio.EQband"]
-
-    async def _update_advanced_audio(self):
-        if self.__execute_status_supported is False:
-            return
-        await self.update_execution_data(["/sec/networkaudio/advancedaudio"])
-        await asyncio.sleep(0.1)
-
-        payload = await self.get_execute_status()
-        retry = 0
-        while "x.com.samsung.networkaudio.nightmode" not in payload and retry < 3:
-            await asyncio.sleep(1)
-            payload = await self.get_execute_status()
-            retry += 1
-        if "x.com.samsung.networkaudio.nightmode" not in payload:
-            log.debug(f"[{DOMAIN}] execute/status did not return advanced-audio payload (device may not support it).")
-            return
-
-        self.__night_mode = payload["x.com.samsung.networkaudio.nightmode"]
-        self.__bass_mode = payload["x.com.samsung.networkaudio.bassboost"]
-        self.__voice_amplifier = payload["x.com.samsung.networkaudio.voiceamplifier"]
+    # ------------ Device information ----------
 
     @property
-    def status(self):
-        return self.device.status
-
-    # ------------ DEVICE INFORMATION ----------
+    def device_id(self) -> str:
+        return self._device_id
 
     @property
-    def manufacturer(self):
-        return self.device.status.ocf_manufacturer_name
-
-    @property
-    def model(self):
-        # Many Samsung OCF devices expose the model in ocf.mnmo (ex: HW-Q990D).
-        return self.device.status.ocf_model_number or self._attr("mnmo")
-
-    @property
-    def firmware_version(self):
-        return self.device.status.ocf_firmware_version or self._attr("mnfv")
-
-    @property
-    def device_id(self):
-        return self.device.device_id
-
-    @property
-    def device_name(self):
+    def device_name(self) -> str:
         return self.__device_name
 
-    # ------------ ON / OFF ------------
+    @property
+    def manufacturer(self) -> str | None:
+        # Prefer OCF, fallback to /devices
+        return self._attr("mnmn") or (self._device or {}).get("manufacturerName")
+
+    @property
+    def model(self) -> str | None:
+        # OCF model (mnmo) is typically set (ex: HW-Q990D)
+        return self._attr("mnmo") or (self._device or {}).get("model")
+
+    @property
+    def firmware_version(self) -> str | None:
+        return self._attr("mnfv")
+
+    # ------------ On / Off ------------
 
     @property
     def state(self) -> str:
-        try:
-            is_on = bool(getattr(self.device.status, "switch"))
-        except Exception:
-            is_on = False
-
+        sw = self._cap_attr("switch", "switch")
+        is_on = (sw == "on") or (sw is True)
         if not is_on:
             return "off"
 
-        # Optional playback status (not available on all models).
-        try:
-            pb = getattr(self.device.status, "playback_status", None)
-            if isinstance(pb, str) and pb:
-                if pb in ("playing", "paused"):
-                    return pb
-        except Exception:
-            pass
-
-        # Fallback to thingStatus (SamsungVD) if present.
-        ts = self._attr("status")
+        # thingStatus is often \"Idle\" when on.
+        ts = self._cap_attr("samsungvd.thingStatus", "status")
         if isinstance(ts, str) and ts.lower() in ("playing", "paused"):
             return ts.lower()
 
         return "on"
 
-    async def switch_off(self):
-        await self.device.switch_off(True)
+    async def switch_off(self) -> None:
+        await self.command("switch", "off", [])
 
-    async def switch_on(self):
-        await self.device.switch_on(True)
+    async def switch_on(self) -> None:
+        await self.command("switch", "on", [])
 
-    # ------------ VOLUME --------------
+    # ------------ Volume / Mute ------------
 
     @property
     def max_volume(self) -> int:
@@ -248,365 +180,343 @@ class SoundbarDevice:
 
     @property
     def volume_level(self) -> float:
-        vol = self.device.status.volume
-        if vol > self.__max_volume:
+        vol = self._cap_attr("audioVolume", "volume")
+        try:
+            vol_int = int(vol)
+        except Exception:
+            vol_int = 0
+        if vol_int > self.__max_volume:
             return 1.0
-        return self.device.status.volume / self.__max_volume
+        return vol_int / float(self.__max_volume)
 
     @property
     def volume_muted(self) -> bool:
-        return self.device.status.mute
+        return bool(self._cap_attr("audioMute", "mute"))
 
-    async def set_volume(self, volume: float):
-        """
-        Sets the volume to a certain level.
-        This respects the max volume and hovers between
-        :param volume: between 0 and 1
-        """
-        await self.device.set_volume(int(volume * self.__max_volume), True)
+    async def set_volume(self, volume: float) -> None:
+        # volume is 0..1 from HA
+        v = int(float(volume) * self.__max_volume)
+        v = max(0, min(self.__max_volume, v))
+        await self.command("audioVolume", "setVolume", [v])
 
-    async def mute_volume(self, mute: bool):
-        if mute:
-            await self.device.mute(True)
-        else:
-            await self.device.unmute(True)
+    async def mute_volume(self, mute: bool) -> None:
+        await self.command("audioMute", "mute" if mute else "unmute", [])
 
-    async def volume_up(self):
-        await self.device.volume_up(True)
+    async def volume_up(self) -> None:
+        await self.command("audioVolume", "volumeUp", [])
 
-    async def volume_down(self):
-        await self.device.volume_down(True)
+    async def volume_down(self) -> None:
+        await self.command("audioVolume", "volumeDown", [])
 
-    # ------------ WOOFER LEVEL -------------
+    # ------------ Input Sources ------------
 
     @property
-    def woofer_level(self) -> int:
-        return self.__woofer_level
+    def input_source(self) -> str | None:
+        return self._cap_attr("samsungvd.audioInputSource", "inputSource")
 
     @property
-    def woofer_connection(self) -> str:
-        return self.__woofer_connection
+    def supported_input_sources(self) -> list[str]:
+        sources = self._cap_attr("samsungvd.audioInputSource", "supportedInputSources")
+        return list(sources) if isinstance(sources, list) else []
 
-    async def set_woofer(self, level: int):
-        await self.set_custom_execution_data(
-            href="/sec/networkaudio/woofer",
-            property="x.com.samsung.networkaudio.woofer",
-            value=level,
-        )
-        self.__woofer_level = level
-
-    # ------------ INPUT SOURCE -------------
-
-    @property
-    def input_source(self):
-        # This device exposes input source via samsungvd.audioInputSource.
-        src = self._attr("inputSource")
-        if src:
-            return src
-        # fallback (older models / pysmartthings property)
-        try:
-            return self.device.status.input_source
-        except Exception:
-            return None
-
-    @property
-    def supported_input_sources(self):
-        sources = self._attr("supportedInputSources")
-        if sources:
-            return sources
-        try:
-            return self.device.status.supported_input_sources
-        except Exception:
-            return []
-
-    async def select_source(self, source: str):
-        sources = list(self.supported_input_sources or [])
+    async def select_source(self, source: str) -> None:
+        sources = self.supported_input_sources
         if not sources:
             raise ValueError("No supported input sources reported by SmartThings")
-
+        if source not in sources:
+            raise ValueError(f"Unsupported source: {source}")
         current = self.input_source
         if current == source:
             return
 
-        if source not in sources:
-            raise ValueError(f"Unsupported source: {source}")
-
-        # The capability only supports 'next' cycling on some devices.
-        # Compute a minimal number of steps to reach the target.
-        try:
-            cur_idx = sources.index(current) if current in sources else 0
-        except Exception:
-            cur_idx = 0
+        cur_idx = sources.index(current) if current in sources else 0
         tgt_idx = sources.index(source)
         steps = (tgt_idx - cur_idx) % len(sources)
         for _ in range(steps):
-            await self.device.command("main", "samsungvd.audioInputSource", "setNextInputSource")
+            await self.command("samsungvd.audioInputSource", "setNextInputSource", [])
             await asyncio.sleep(0.6)
-        await self.device.status.refresh()
+            await self._refresh_status_only()
 
-    # ------------- SOUND MODE --------------
+    async def _refresh_status_only(self) -> None:
+        self._status = await self._api.get_status(self._device_id)
+        self._main = (
+            (self._status.get("components") or {}).get("main") or {}
+            if isinstance(self._status, dict)
+            else {}
+        )
+
+    # ------------ Media metadata (limited) ------------
+
     @property
-    def sound_mode(self):
+    def media_title(self) -> str | None:
+        return self.__media_title
+
+    @property
+    def media_artist(self) -> str | None:
+        return self.__media_artist
+
+    @property
+    def media_coverart_url(self) -> str | None:
+        return self.__media_cover_url
+
+    @property
+    def media_coverart_updated(self) -> dt.datetime | None:
+        return self.__media_cover_url_update_time
+
+    @property
+    def media_duration(self) -> int | None:
+        return None
+
+    @property
+    def media_position(self) -> int | None:
+        return None
+
+    @property
+    def media_app_name(self) -> str | None:
+        return self._cap_attr("samsungvd.soundFrom", "detailName")
+
+    # Media playback is not exposed for many OCF soundbars via SmartThings.
+    # Keep stubs so entity code can call them safely if ever enabled.
+
+    async def media_play(self) -> None:
+        raise NotImplementedError("Media playback is not supported by this device via SmartThings")
+
+    async def media_pause(self) -> None:
+        raise NotImplementedError("Media playback is not supported by this device via SmartThings")
+
+    async def media_stop(self) -> None:
+        raise NotImplementedError("Media playback is not supported by this device via SmartThings")
+
+    async def media_next_track(self) -> None:
+        raise NotImplementedError("Media playback is not supported by this device via SmartThings")
+
+    async def media_previous_track(self) -> None:
+        raise NotImplementedError("Media playback is not supported by this device via SmartThings")
+
+    # ------------ Execute-based features (may not work on OCF models) ------------
+
+    async def get_execute_status(self) -> dict[str, Any]:
+        # execute status is also exposed as /status under execute.data.value
+        data = self._cap_attr("execute", "data")
+        if isinstance(data, dict):
+            payload = (data.get("payload") or {}) if isinstance(data.get("payload"), dict) else {}
+            self.__execute_status_supported = bool(payload)
+            return payload
+
+        # Fall back to dedicated endpoint (often returns null on OCF models)
+        try:
+            resp = await self._api.get(f"/devices/{self._device_id}/components/main/capabilities/execute/status")
+        except Exception:
+            self.__execute_status_supported = False
+            return {}
+        if not isinstance(resp, dict) or "error" in resp:
+            self.__execute_status_supported = False
+            return {}
+        value = ((resp.get("data") or {}).get("value"))
+        if not isinstance(value, dict):
+            self.__execute_status_supported = False
+            return {}
+        payload = value.get("payload")
+        if isinstance(payload, dict):
+            self.__execute_status_supported = True
+            return payload
+        self.__execute_status_supported = False
+        return {}
+
+    async def set_custom_execution_data(self, href: str, property: str, value: Any) -> None:
+        # execute.execute(command, args)
+        await self.command("execute", "execute", [href, {property: value}])
+
+    async def execute_set_raw(self, href: str, prop: str, value: Any) -> None:
+        await self.set_custom_execution_data(href=href, property=prop, value=value)
+
+    async def ocf_post(self, href: str, value: dict[str, Any]) -> None:
+        await self.command("ocf", "postOcfCommand", [href, value])
+
+    # The following helpers keep old service names; on OCF models they may no-op if status doesn't exist.
+
+    async def _update_soundmode(self) -> None:
+        if self.__execute_status_supported is False:
+            return
+        await self.command("execute", "execute", ["/sec/networkaudio/soundmode"])
+        await asyncio.sleep(0.5)
+        payload = await self.get_execute_status()
+        self.__supported_soundmodes = list(payload.get("x.com.samsung.networkaudio.supportedSoundmode") or [])
+        self.__active_soundmode = payload.get("x.com.samsung.networkaudio.soundmode")
+
+    async def _update_woofer(self) -> None:
+        if self.__execute_status_supported is False:
+            return
+        await self.command("execute", "execute", ["/sec/networkaudio/woofer"])
+        await asyncio.sleep(0.5)
+        payload = await self.get_execute_status()
+        self.__woofer_level = payload.get("x.com.samsung.networkaudio.woofer")
+        self.__woofer_connection = payload.get("x.com.samsung.networkaudio.connection")
+
+    async def _update_equalizer(self) -> None:
+        if self.__execute_status_supported is False:
+            return
+        await self.command("execute", "execute", ["/sec/networkaudio/eq"])
+        await asyncio.sleep(0.5)
+        payload = await self.get_execute_status()
+        self.__active_eq_preset = payload.get("x.com.samsung.networkaudio.EQname")
+        self.__supported_eq_presets = list(payload.get("x.com.samsung.networkaudio.supportedList") or [])
+        self.__eq_action = payload.get("x.com.samsung.networkaudio.action")
+        self.__eq_bands = payload.get("x.com.samsung.networkaudio.EQband")
+
+    async def _update_advanced_audio(self) -> None:
+        if self.__execute_status_supported is False:
+            return
+        await self.command("execute", "execute", ["/sec/networkaudio/advancedaudio"])
+        await asyncio.sleep(0.5)
+        payload = await self.get_execute_status()
+        self.__night_mode = payload.get("x.com.samsung.networkaudio.nightmode")
+        self.__bass_mode = payload.get("x.com.samsung.networkaudio.bassboost")
+        self.__voice_amplifier = payload.get("x.com.samsung.networkaudio.voiceamplifier")
+
+    # ------------ Sound mode (execute-based) ------------
+
+    @property
+    def sound_mode(self) -> str | None:
         return self.__active_soundmode
 
     @property
-    def supported_soundmodes(self):
+    def supported_soundmodes(self) -> list[str]:
         return self.__supported_soundmodes
 
-    async def select_sound_mode(self, sound_mode: str):
+    async def select_sound_mode(self, sound_mode: str) -> None:
         await self.set_custom_execution_data(
             href="/sec/networkaudio/soundmode",
             property="x.com.samsung.networkaudio.soundmode",
             value=sound_mode,
         )
 
-    # ------------- ADVANCED AUDIO ---------------
+    # ------------ Advanced audio toggles (execute-based) ------------
 
     @property
     def night_mode(self) -> bool:
-        return True if self.__night_mode == 1 else False
+        return bool(self.__night_mode == 1)
 
-    async def set_night_mode(self, value: bool):
+    async def set_night_mode(self, value: bool) -> None:
         await self.set_custom_execution_data(
             href="/sec/networkaudio/advancedaudio",
             property="x.com.samsung.networkaudio.nightmode",
             value=1 if value else 0,
         )
-        self.__night_mode = 1 if value else 0
 
     @property
     def bass_mode(self) -> bool:
-        return True if self.__bass_mode == 1 else False
+        return bool(self.__bass_mode == 1)
 
-    async def set_bass_mode(self, value: bool):
+    async def set_bass_mode(self, value: bool) -> None:
         await self.set_custom_execution_data(
             href="/sec/networkaudio/advancedaudio",
             property="x.com.samsung.networkaudio.bassboost",
             value=1 if value else 0,
         )
-        self.__bass_mode = 1 if value else 0
 
     @property
     def voice_amplifier(self) -> bool:
-        return True if self.__voice_amplifier == 1 else False
+        return bool(self.__voice_amplifier == 1)
 
-    async def set_voice_amplifier(self, value: bool):
+    async def set_voice_amplifier(self, value: bool) -> None:
         await self.set_custom_execution_data(
             href="/sec/networkaudio/advancedaudio",
             property="x.com.samsung.networkaudio.voiceamplifier",
             value=1 if value else 0,
         )
-        self.__voice_amplifier = 1 if value else 0
 
-    # ------------ EQUALIZER --------------
+    # ------------ Equalizer (execute-based) ------------
 
     @property
-    def active_equalizer_preset(self):
+    def active_equalizer_preset(self) -> str | None:
         return self.__active_eq_preset
 
     @property
-    def supported_equalizer_presets(self):
+    def supported_equalizer_presets(self) -> list[str]:
         return self.__supported_eq_presets
 
     @property
-    def equalizer_action(self):
+    def equalizer_action(self) -> Any:
         return self.__eq_action
 
     @property
-    def equalizer_bands(self):
+    def equalizer_bands(self) -> Any:
         return self.__eq_bands
 
-    async def set_equalizer_preset(self, preset: str):
+    async def set_equalizer_preset(self, preset: str) -> None:
         await self.set_custom_execution_data(
             href="/sec/networkaudio/eq",
             property="x.com.samsung.networkaudio.EQname",
             value=preset,
         )
 
-    # ------------- MEDIA ----------------
-    @property
-    def media_title(self):
-        return self.__media_title
+    # ------------ Woofer (execute-based) ------------
 
     @property
-    def media_artist(self):
-        return self.__media_artist
+    def woofer_level(self) -> int | None:
+        return self.__woofer_level
 
     @property
-    def media_coverart_url(self):
-        return self.__media_cover_url
+    def woofer_connection(self) -> str | None:
+        return self.__woofer_connection
 
-    @property
-    def media_duration(self) -> int | None:
-        attr = self.device.status.attributes.get("totalTime", None)
-        if attr:
-            return attr.value
+    async def set_woofer(self, level: int) -> None:
+        await self.set_custom_execution_data(
+            href="/sec/networkaudio/woofer",
+            property="x.com.samsung.networkaudio.woofer",
+            value=level,
+        )
 
-    @property
-    def media_position(self) -> int | None:
-        attr = self.device.status.attributes.get("elapsedTime", None)
-        if attr:
-            return attr.value
+    # ------------ Speaker level (execute-based) ------------
 
-    async def media_play(self):
-        if not hasattr(self.device, "play"):
-            raise NotImplementedError("Play not supported by this device")
-        await self.device.play(True)
-
-    async def media_pause(self):
-        if not hasattr(self.device, "pause"):
-            raise NotImplementedError("Pause not supported by this device")
-        await self.device.pause(True)
-
-    async def media_stop(self):
-        if not hasattr(self.device, "stop"):
-            raise NotImplementedError("Stop not supported by this device")
-        await self.device.stop(True)
-
-    async def media_next_track(self):
-        await self.device.command("main", "mediaPlayback", "fastForward")
-
-    async def media_previous_track(self):
-        await self.device.command("main", "mediaPlayback", "rewind")
-
-    @property
-    def media_app_name(self):
-        # Reported by samsungvd.soundFrom.detailName on newer models.
-        return self._attr("detailName")
-
-    @property
-    def media_coverart_updated(self) -> datetime.datetime:
-        return self.__media_cover_url_update_time
-
-    # ------------ Speaker Level ----------------
-
-    async def set_speaker_level(self, speaker: SpeakerIdentifier, level: int):
+    async def set_speaker_level(self, speaker: SpeakerIdentifier, level: int) -> None:
         await self.set_custom_execution_data(
             href="/sec/networkaudio/channelVolume",
             property="x.com.samsung.networkaudio.channelVolume",
             value=[{"name": speaker.value, "value": level}],
         )
 
-    async def set_rear_speaker_mode(self, mode: RearSpeakerMode):
+    async def set_rear_speaker_mode(self, mode: RearSpeakerMode) -> None:
         await self.set_custom_execution_data(
             href="/sec/networkaudio/surroundspeaker",
             property="x.com.samsung.networkaudio.currentRearPosition",
             value=mode.value,
         )
 
-    # ------------ OTHER FUNCTIONS ------------
-
-    async def set_active_voice_amplifier(self, enabled: bool):
+    async def set_active_voice_amplifier(self, enabled: bool) -> None:
         await self.set_custom_execution_data(
             href="/sec/networkaudio/activeVoiceAmplifier",
             property="x.com.samsung.networkaudio.activeVoiceAmplifier",
-            value=1 if enabled else 0
+            value=1 if enabled else 0,
         )
 
-    async def set_space_fit_sound(self, enabled: bool):
+    async def set_space_fit_sound(self, enabled: bool) -> None:
         await self.set_custom_execution_data(
             href="/sec/networkaudio/spacefitSound",
             property="x.com.samsung.networkaudio.spacefitSound",
-            value=1 if enabled else 0
+            value=1 if enabled else 0,
         )
 
-    # ------------ SUPPORT FUNCTIONS ------------
+    # ------------ Audio notifications (native capability) ------------
 
-    async def update_execution_data(self, argument: str):
-        stuff = await self.device.command("main", "execute", "execute", argument)
-        return stuff
+    async def play_track(self, uri: str, level: int | None = None) -> None:
+        args = [uri] if level is None else [uri, level]
+        await self.command("audioNotification", "playTrack", args)
 
-    async def set_custom_execution_data(self, href: str, property: str, value):
-        argument = [href, {property: value}]
-        assert await self.device.command("main", "execute", "execute", argument)
+    async def play_track_and_restore(self, uri: str, level: int | None = None) -> None:
+        args = [uri] if level is None else [uri, level]
+        await self.command("audioNotification", "playTrackAndRestore", args)
 
-    async def execute_set_raw(self, href: str, prop: str, value: Any):
-        """Power-user escape hatch: set any execute href/property/value."""
-        await self.set_custom_execution_data(href=href, property=prop, value=value)
+    async def play_track_and_resume(self, uri: str, level: int | None = None) -> None:
+        args = [uri] if level is None else [uri, level]
+        await self.command("audioNotification", "playTrackAndResume", args)
 
-    async def ocf_post(self, href: str, value: dict[str, Any]):
-        """Send an OCF command (if supported by the device)."""
-        await self.device.command("main", "ocf", "postOcfCommand", [href, value])
-
-    async def get_execute_status(self):
-        url = f"https://api.smartthings.com/v1/devices/{self._device_id}/components/main/capabilities/execute/status"
-        request_headers = {"Authorization": "Bearer " + self._api_key}
-        resp = await self.__session.get(url, headers=request_headers)
-        dict_stuff = await resp.json()
-        # Some devices return {"data":{"value": null}} or an error object here.
-        if not isinstance(dict_stuff, dict) or "error" in dict_stuff:
-            self.__execute_status_supported = False
-            return {}
-        data = dict_stuff.get("data") or {}
-        if not isinstance(data, dict):
-            self.__execute_status_supported = False
-            return {}
-        value = data.get("value")
-        if not isinstance(value, dict):
-            # If we consistently see null here, stop trying execute/status to avoid rate limits.
-            self.__execute_status_supported = False
-            return {}
-        payload = value.get("payload")
-        self.__execute_status_supported = isinstance(payload, dict)
-        return payload if isinstance(payload, dict) else {}
-
-    async def get_song_title_artwork(self, artist: str, title: str) -> str:
-        """
-        This function loads a Music Art Cover from iTunes based on
-        the title and the artist
-        :param artist: string
-        :param title: string
-        :return: url as string
-        """
-        query_term = f"{artist} {title}"
-        url = "https://itunes.apple.com/search?term=%s&media=music&entity=%s" % (
-            quote(query_term),
-            "musicTrack",
-        )
-        resp = await self.__session.get(url)
-        resp_dict = json.loads(await resp.text())
-        if len(resp_dict["results"]) != 0:
-            return resp_dict["results"][0]["artworkUrl100"]
+    # ------------ Read-only debug blob ------------
 
     @property
-    def retrieve_data(self):
+    def retrieve_data(self) -> dict[str, Any]:
         return {
-            "status": self.state,
-            "device_information": {
-                "model": self.model,
-                "manufacture": self.manufacturer,
-                "firmware_version": self.firmware_version,
-                "device_id": self.device_id,
-            },
-            "volume": {"level": self.volume_level, "muted": self.volume_muted},
-            "woofer": {
-                "level": self.woofer_level,
-                "connection": self.woofer_connection,
-            },
-            "source": {
-                "active_source": self.input_source,
-                "supported_sources": self.supported_input_sources,
-            },
-            "sound_mode": {
-                "active_sound_mode": self.sound_mode,
-                "supported_sound_modes": self.supported_soundmodes,
-            },
-            "advanced_audio": {
-                "night_mode": self.night_mode,
-                "bass_mode": self.bass_mode,
-                "voice_amplifier": self.voice_amplifier,
-            },
-            "equalizer": {
-                "active_preset": self.active_equalizer_preset,
-                "supported_presets": self.supported_equalizer_presets,
-                "action": self.equalizer_action,
-                "bands": self.equalizer_bands,
-            },
-            "media": {
-                "media_title": self.media_title,
-                "media_artist": self.media_artist,
-                "media_cover_url": self.media_coverart_url,
-                "media_duration": self.media_duration,
-                "media_position": self.media_position,
-            },
+            "device": self._device,
+            "status": self._status,
         }

--- a/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
+++ b/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
@@ -117,6 +117,7 @@ class SoundbarDevice:
         )
 
         # Cache fields that we expose as properties
+        self._update_media_metadata()
         if self.__enable_soundmode:
             await self._update_soundmode()
         if self.__enable_advanced_audio:
@@ -244,6 +245,50 @@ class SoundbarDevice:
             if isinstance(self._status, dict)
             else {}
         )
+
+    def _update_media_metadata(self) -> None:
+        """Best-effort extraction of title/artist from SmartThings status payload.
+
+        Different models/firmware expose this data in different capabilities and
+        shapes (dict or JSON string). Keep this permissive and non-fatal.
+        """
+        track = (
+            self._attr("audioTrackData")
+            or self._attr("musicTrack")
+            or self._attr("trackData")
+        )
+
+        title: str | None = None
+        artist: str | None = None
+
+        if isinstance(track, str):
+            try:
+                parsed = json.loads(track)
+            except Exception:
+                parsed = None
+            if isinstance(parsed, dict):
+                track = parsed
+
+        if isinstance(track, dict):
+            raw_title = track.get("title") or track.get("trackTitle") or track.get("name")
+            raw_artist = track.get("artist") or track.get("artistName")
+            if isinstance(raw_title, str) and raw_title.strip():
+                title = raw_title.strip()
+            if isinstance(raw_artist, str) and raw_artist.strip():
+                artist = raw_artist.strip()
+
+        # Some payloads expose title/artist as separate attributes.
+        if title is None:
+            raw_title = self._attr("title")
+            if isinstance(raw_title, str) and raw_title.strip():
+                title = raw_title.strip()
+        if artist is None:
+            raw_artist = self._attr("artist")
+            if isinstance(raw_artist, str) and raw_artist.strip():
+                artist = raw_artist.strip()
+
+        self.__media_title = title
+        self.__media_artist = artist
 
     # ------------ Media metadata (limited) ------------
 

--- a/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
+++ b/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
@@ -66,7 +66,7 @@ class SoundbarDevice:
             await self._update_soundmode()
         if self.__enable_advanced_audio:
             await self._update_advanced_audio()
-        if self.__enable_soundmode:
+        if self.__enable_woofer:
             await self._update_woofer()
         if self.__enable_eq:
             await self._update_equalizer()
@@ -236,9 +236,9 @@ class SoundbarDevice:
 
     async def mute_volume(self, mute: bool):
         if mute:
-            await self.device.unmute(True)
-        else:
             await self.device.mute(True)
+        else:
+            await self.device.unmute(True)
 
     async def volume_up(self):
         await self.device.volume_up(True)

--- a/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
+++ b/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
@@ -56,6 +56,15 @@ class SoundbarDevice:
         self.__old_media_title = ""
 
         self.__max_volume = max_volume
+        self.__execute_status_supported: bool | None = None
+
+    def _attr(self, name: str):
+        """Best-effort attribute lookup from SmartThings status."""
+        try:
+            attr = self.device.status.attributes.get(name)
+        except Exception:
+            attr = None
+        return attr.value if attr is not None else None
 
     async def update(self):
         await self.device.status.refresh()
@@ -87,6 +96,8 @@ class SoundbarDevice:
                 )
 
     async def _update_soundmode(self):
+        if self.__execute_status_supported is False:
+            return
         await self.update_execution_data(["/sec/networkaudio/soundmode"])
         await asyncio.sleep(1)
         payload = await self.get_execute_status()
@@ -109,6 +120,8 @@ class SoundbarDevice:
         self.__active_soundmode = payload["x.com.samsung.networkaudio.soundmode"]
 
     async def _update_woofer(self):
+        if self.__execute_status_supported is False:
+            return
         await self.update_execution_data(["/sec/networkaudio/woofer"])
         await asyncio.sleep(0.1)
         payload = await self.get_execute_status()
@@ -124,6 +137,8 @@ class SoundbarDevice:
         self.__woofer_connection = payload["x.com.samsung.networkaudio.connection"]
 
     async def _update_equalizer(self):
+        if self.__execute_status_supported is False:
+            return
         await self.update_execution_data(["/sec/networkaudio/eq"])
         await asyncio.sleep(0.1)
         payload = await self.get_execute_status()
@@ -143,6 +158,8 @@ class SoundbarDevice:
         self.__eq_bands = payload["x.com.samsung.networkaudio.EQband"]
 
     async def _update_advanced_audio(self):
+        if self.__execute_status_supported is False:
+            return
         await self.update_execution_data(["/sec/networkaudio/advancedaudio"])
         await asyncio.sleep(0.1)
 
@@ -172,11 +189,12 @@ class SoundbarDevice:
 
     @property
     def model(self):
-        return self.device.status.ocf_model_number
+        # Many Samsung OCF devices expose the model in ocf.mnmo (ex: HW-Q990D).
+        return self.device.status.ocf_model_number or self._attr("mnmo")
 
     @property
     def firmware_version(self):
-        return self.device.status.ocf_firmware_version
+        return self.device.status.ocf_firmware_version or self._attr("mnfv")
 
     @property
     def device_id(self):
@@ -207,6 +225,10 @@ class SoundbarDevice:
         await self.device.switch_on(True)
 
     # ------------ VOLUME --------------
+
+    @property
+    def max_volume(self) -> int:
+        return self.__max_volume
 
     @property
     def volume_level(self) -> float:
@@ -261,16 +283,50 @@ class SoundbarDevice:
 
     @property
     def input_source(self):
-        if self.media_app_name in ("AirPlay", "Spotify"):
-            return "wifi"
-        return self.device.status.input_source
+        # This device exposes input source via samsungvd.audioInputSource.
+        src = self._attr("inputSource")
+        if src:
+            return src
+        # fallback (older models / pysmartthings property)
+        try:
+            return self.device.status.input_source
+        except Exception:
+            return None
 
     @property
     def supported_input_sources(self):
-        return self.device.status.supported_input_sources
+        sources = self._attr("supportedInputSources")
+        if sources:
+            return sources
+        try:
+            return self.device.status.supported_input_sources
+        except Exception:
+            return []
 
     async def select_source(self, source: str):
-        await self.device.set_input_source(source, True)
+        sources = list(self.supported_input_sources or [])
+        if not sources:
+            raise ValueError("No supported input sources reported by SmartThings")
+
+        current = self.input_source
+        if current == source:
+            return
+
+        if source not in sources:
+            raise ValueError(f"Unsupported source: {source}")
+
+        # The capability only supports 'next' cycling on some devices.
+        # Compute a minimal number of steps to reach the target.
+        try:
+            cur_idx = sources.index(current) if current in sources else 0
+        except Exception:
+            cur_idx = 0
+        tgt_idx = sources.index(source)
+        steps = (tgt_idx - cur_idx) % len(sources)
+        for _ in range(steps):
+            await self.device.command("main", "samsungvd.audioInputSource", "setNextInputSource")
+            await asyncio.sleep(0.6)
+        await self.device.status.refresh()
 
     # ------------- SOUND MODE --------------
     @property
@@ -393,10 +449,8 @@ class SoundbarDevice:
 
     @property
     def media_app_name(self):
-        detail_status = self.device.status.attributes.get("detailName", None)
-        if detail_status is not None:
-            return detail_status.value
-        return None
+        # Reported by samsungvd.soundFrom.detailName on newer models.
+        return self._attr("detailName")
 
     @property
     def media_coverart_updated(self) -> datetime.datetime:
@@ -451,14 +505,19 @@ class SoundbarDevice:
         dict_stuff = await resp.json()
         # Some devices return {"data":{"value": null}} or an error object here.
         if not isinstance(dict_stuff, dict) or "error" in dict_stuff:
+            self.__execute_status_supported = False
             return {}
         data = dict_stuff.get("data") or {}
         if not isinstance(data, dict):
+            self.__execute_status_supported = False
             return {}
         value = data.get("value")
         if not isinstance(value, dict):
+            # If we consistently see null here, stop trying execute/status to avoid rate limits.
+            self.__execute_status_supported = False
             return {}
         payload = value.get("payload")
+        self.__execute_status_supported = isinstance(payload, dict)
         return payload if isinstance(payload, dict) else {}
 
     async def get_song_title_artwork(self, artist: str, title: str) -> str:

--- a/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
+++ b/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
@@ -520,6 +520,14 @@ class SoundbarDevice:
         argument = [href, {property: value}]
         assert await self.device.command("main", "execute", "execute", argument)
 
+    async def execute_set_raw(self, href: str, prop: str, value: Any):
+        """Power-user escape hatch: set any execute href/property/value."""
+        await self.set_custom_execution_data(href=href, property=prop, value=value)
+
+    async def ocf_post(self, href: str, value: dict[str, Any]):
+        """Send an OCF command (if supported by the device)."""
+        await self.device.command("main", "ocf", "postOcfCommand", [href, value])
+
     async def get_execute_status(self):
         url = f"https://api.smartthings.com/v1/devices/{self._device_id}/components/main/capabilities/execute/status"
         request_headers = {"Authorization": "Bearer " + self._api_key}

--- a/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
+++ b/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
@@ -210,15 +210,29 @@ class SoundbarDevice:
 
     @property
     def state(self) -> str:
-        if self.device.status.switch:
-            if self.device.status.playback_status == "playing":
-                return "playing"
-            if self.device.status.playback_status == "paused":
-                return "paused"
-            else:
-                return "on"
-        else:
+        try:
+            is_on = bool(getattr(self.device.status, "switch"))
+        except Exception:
+            is_on = False
+
+        if not is_on:
             return "off"
+
+        # Optional playback status (not available on all models).
+        try:
+            pb = getattr(self.device.status, "playback_status", None)
+            if isinstance(pb, str) and pb:
+                if pb in ("playing", "paused"):
+                    return pb
+        except Exception:
+            pass
+
+        # Fallback to thingStatus (SamsungVD) if present.
+        ts = self._attr("status")
+        if isinstance(ts, str) and ts.lower() in ("playing", "paused"):
+            return ts.lower()
+
+        return "on"
 
     async def switch_off(self):
         await self.device.switch_off(True)
@@ -435,12 +449,18 @@ class SoundbarDevice:
             return attr.value
 
     async def media_play(self):
+        if not hasattr(self.device, "play"):
+            raise NotImplementedError("Play not supported by this device")
         await self.device.play(True)
 
     async def media_pause(self):
+        if not hasattr(self.device, "pause"):
+            raise NotImplementedError("Pause not supported by this device")
         await self.device.pause(True)
 
     async def media_stop(self):
+        if not hasattr(self.device, "stop"):
+            raise NotImplementedError("Stop not supported by this device")
         await self.device.stop(True)
 
     async def media_next_track(self):

--- a/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
+++ b/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
@@ -91,17 +91,16 @@ class SoundbarDevice:
         await asyncio.sleep(1)
         payload = await self.get_execute_status()
         retry = 0
+        # execute/status is rate limited and may be empty/null for some devices (e.g. newer OCF models).
         while (
-                "x.com.samsung.networkaudio.supportedSoundmode" not in payload
-                and retry < 10
+            "x.com.samsung.networkaudio.supportedSoundmode" not in payload
+            and retry < 3
         ):
-            await asyncio.sleep(1)
+            await asyncio.sleep(2)
             payload = await self.get_execute_status()
             retry += 1
-        if retry == 10:
-            log.error(
-                f"[{DOMAIN}] Error: _update_soundmode exceeded a retry counter of 10"
-            )
+        if "x.com.samsung.networkaudio.supportedSoundmode" not in payload:
+            log.debug(f"[{DOMAIN}] execute/status did not return soundmode payload (device may not support it).")
             return
 
         self.__supported_soundmodes = payload[
@@ -114,14 +113,12 @@ class SoundbarDevice:
         await asyncio.sleep(0.1)
         payload = await self.get_execute_status()
         retry = 0
-        while "x.com.samsung.networkaudio.woofer" not in payload and retry < 10:
-            await asyncio.sleep(0.2)
+        while "x.com.samsung.networkaudio.woofer" not in payload and retry < 3:
+            await asyncio.sleep(1)
             payload = await self.get_execute_status()
             retry += 1
-        if retry == 10:
-            log.error(
-                f"[{DOMAIN}] Error: _update_woofer exceeded a retry counter of 10"
-            )
+        if "x.com.samsung.networkaudio.woofer" not in payload:
+            log.debug(f"[{DOMAIN}] execute/status did not return woofer payload (device may not support it).")
             return
         self.__woofer_level = payload["x.com.samsung.networkaudio.woofer"]
         self.__woofer_connection = payload["x.com.samsung.networkaudio.connection"]
@@ -131,14 +128,12 @@ class SoundbarDevice:
         await asyncio.sleep(0.1)
         payload = await self.get_execute_status()
         retry = 0
-        while "x.com.samsung.networkaudio.EQname" not in payload and retry < 10:
-            await asyncio.sleep(0.2)
+        while "x.com.samsung.networkaudio.EQname" not in payload and retry < 3:
+            await asyncio.sleep(1)
             payload = await self.get_execute_status()
             retry += 1
-        if retry == 10:
-            log.error(
-                f"[{DOMAIN}] Error: _update_equalizer exceeded a retry counter of 10"
-            )
+        if "x.com.samsung.networkaudio.EQname" not in payload:
+            log.debug(f"[{DOMAIN}] execute/status did not return equalizer payload (device may not support it).")
             return
         self.__active_eq_preset = payload["x.com.samsung.networkaudio.EQname"]
         self.__supported_eq_presets = payload[
@@ -153,14 +148,12 @@ class SoundbarDevice:
 
         payload = await self.get_execute_status()
         retry = 0
-        while "x.com.samsung.networkaudio.nightmode" not in payload and retry < 10:
-            await asyncio.sleep(0.2)
+        while "x.com.samsung.networkaudio.nightmode" not in payload and retry < 3:
+            await asyncio.sleep(1)
             payload = await self.get_execute_status()
             retry += 1
-        if retry == 10:
-            log.error(
-                f"[{DOMAIN}] Error: _update_advanced_audio exceeded a retry counter of 10"
-            )
+        if "x.com.samsung.networkaudio.nightmode" not in payload:
+            log.debug(f"[{DOMAIN}] execute/status did not return advanced-audio payload (device may not support it).")
             return
 
         self.__night_mode = payload["x.com.samsung.networkaudio.nightmode"]
@@ -456,7 +449,17 @@ class SoundbarDevice:
         request_headers = {"Authorization": "Bearer " + self._api_key}
         resp = await self.__session.get(url, headers=request_headers)
         dict_stuff = await resp.json()
-        return dict_stuff["data"]["value"]["payload"]
+        # Some devices return {"data":{"value": null}} or an error object here.
+        if not isinstance(dict_stuff, dict) or "error" in dict_stuff:
+            return {}
+        data = dict_stuff.get("data") or {}
+        if not isinstance(data, dict):
+            return {}
+        value = data.get("value")
+        if not isinstance(value, dict):
+            return {}
+        payload = value.get("payload")
+        return payload if isinstance(payload, dict) else {}
 
     async def get_song_title_artwork(self, artist: str, title: str) -> str:
         """

--- a/custom_components/samsung_soundbar/button.py
+++ b/custom_components/samsung_soundbar/button.py
@@ -38,9 +38,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     key="next_input_source",
                     name="Next Input Source",
                     icon="mdi:skip-next",
-                    press=lambda d: d.device.command(
-                        "main", "samsungvd.audioInputSource", "setNextInputSource"
-                    ),
+                    press=lambda d: d.command("samsungvd.audioInputSource", "setNextInputSource", []),
                 ),
             ]
         )
@@ -71,4 +69,3 @@ class SoundbarButton(CoordinatorEntity, ButtonEntity):
         dev: SoundbarDevice = self.coordinator.data
         await self._press(dev)
         await self.coordinator.async_request_refresh()
-

--- a/custom_components/samsung_soundbar/button.py
+++ b/custom_components/samsung_soundbar/button.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .api_extension.SoundbarDevice import SoundbarDevice
+from .const import CONF_ENTRY_DEVICE_ID, DOMAIN
+from .models import DeviceConfig
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    domain_data = hass.data[DOMAIN]
+    entities: list[ButtonEntity] = []
+
+    for key in domain_data.devices:
+        device_config: DeviceConfig = domain_data.devices[key]
+        device = device_config.device
+        coordinator = device_config.coordinator
+        if device.device_id != config_entry.data.get(CONF_ENTRY_DEVICE_ID):
+            continue
+
+        entities.extend(
+            [
+                SoundbarButton(
+                    coordinator,
+                    key="refresh",
+                    name="Refresh",
+                    icon="mdi:refresh",
+                    press=lambda d: coordinator.async_request_refresh(),
+                ),
+                SoundbarButton(
+                    coordinator,
+                    key="next_input_source",
+                    name="Next Input Source",
+                    icon="mdi:skip-next",
+                    press=lambda d: d.device.command(
+                        "main", "samsungvd.audioInputSource", "setNextInputSource"
+                    ),
+                ),
+            ]
+        )
+
+    async_add_entities(entities)
+    return True
+
+
+class SoundbarButton(CoordinatorEntity, ButtonEntity):
+    def __init__(self, coordinator, *, key: str, name: str, icon: str, press):
+        super().__init__(coordinator)
+        self._key = key
+        self._attr_name = name
+        self._attr_icon = icon
+        self._press = press
+
+        dev: SoundbarDevice = coordinator.data
+        self._attr_unique_id = f"{dev.device_id}_{key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, dev.device_id)},
+            name=dev.device_name,
+            manufacturer=dev.manufacturer,
+            model=dev.model,
+            sw_version=dev.firmware_version,
+        )
+
+    async def async_press(self) -> None:
+        dev: SoundbarDevice = self.coordinator.data
+        await self._press(dev)
+        await self.coordinator.async_request_refresh()
+

--- a/custom_components/samsung_soundbar/config_flow.py
+++ b/custom_components/samsung_soundbar/config_flow.py
@@ -1,12 +1,11 @@
 import logging
 from typing import Any
 
-import pysmartthings
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from voluptuous import All, Range
 
+from .smartthings_api import SmartThingsApi
 from .const import (
     CONF_ENTRY_API_KEY,
     CONF_ENTRY_DEVICE_ID,
@@ -22,13 +21,9 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-async def validate_input(api, device_id: str):
-    try:
-        return await api.device(device_id)
-    except Exception as excp:
-        # pysmartthings exception classes changed across versions; avoid hard dependency.
-        _LOGGER.error("[Samsung Soundbar] ERROR validating device id: %s", str(excp))
-        raise ValueError
+async def validate_input(hass, token: str, device_id: str) -> dict[str, Any]:
+    api = SmartThingsApi(hass, token)
+    return await api.get_device(device_id)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -51,24 +46,34 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
         )
 
-    async def async_step_device(self, user_input: dict[str, any] | None = None):
+    async def async_step_device(self, user_input: dict[str, Any] | None = None):
         if user_input is not None:
             self.user_input.update(user_input)
 
             try:
-                session = async_get_clientsession(self.hass)
-                api = pysmartthings.SmartThings(
-                    session, self.user_input.get(CONF_ENTRY_API_KEY)
-                )
                 device = await validate_input(
-                    api, self.user_input.get(CONF_ENTRY_DEVICE_ID)
+                    self.hass,
+                    self.user_input.get(CONF_ENTRY_API_KEY),
+                    self.user_input.get(CONF_ENTRY_DEVICE_ID),
                 )
                 _LOGGER.debug(
                     f"Successfully validated Input, Creating entry with title {DOMAIN} and data {user_input}"
                 )
             except Exception as excp:
-                _LOGGER.error(f"The ConfigFlow triggered an exception {excp}")
-                return self.async_abort(reason="fetch_failed")
+                _LOGGER.exception("Config flow validation failed")
+                # Keep the user on the same step with a useful base error.
+                return self.async_show_form(
+                    step_id="device",
+                    data_schema=vol.Schema(
+                        {
+                            vol.Required(CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES, default=self.user_input.get(CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES, False)): bool,
+                            vol.Required(CONF_ENTRY_SETTINGS_EQ_SELECTOR, default=self.user_input.get(CONF_ENTRY_SETTINGS_EQ_SELECTOR, False)): bool,
+                            vol.Required(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR, default=self.user_input.get(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR, False)): bool,
+                            vol.Required(CONF_ENTRY_SETTINGS_WOOFER_NUMBER, default=self.user_input.get(CONF_ENTRY_SETTINGS_WOOFER_NUMBER, False)): bool,
+                        }
+                    ),
+                    errors={"base": "fetch_failed"},
+                )
             return self.async_create_entry(title=DOMAIN, data=self.user_input)
 
         return self.async_show_form(

--- a/custom_components/samsung_soundbar/config_flow.py
+++ b/custom_components/samsung_soundbar/config_flow.py
@@ -5,7 +5,6 @@ import pysmartthings
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from pysmartthings import APIResponseError
 from voluptuous import All, Range
 
 from .const import (
@@ -26,8 +25,9 @@ _LOGGER = logging.getLogger(__name__)
 async def validate_input(api, device_id: str):
     try:
         return await api.device(device_id)
-    except APIResponseError as excp:
-        _LOGGER.error("[Samsung Soundbar] ERROR: %s", str(excp))
+    except Exception as excp:
+        # pysmartthings exception classes changed across versions; avoid hard dependency.
+        _LOGGER.error("[Samsung Soundbar] ERROR validating device id: %s", str(excp))
         raise ValueError
 
 

--- a/custom_components/samsung_soundbar/config_flow.py
+++ b/custom_components/samsung_soundbar/config_flow.py
@@ -31,7 +31,7 @@ async def validate_input(api, device_id: str):
         raise ValueError
 
 
-class ExampleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         if user_input is not None:
             self.user_input = user_input

--- a/custom_components/samsung_soundbar/config_flow.py
+++ b/custom_components/samsung_soundbar/config_flow.py
@@ -75,10 +75,10 @@ class ExampleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="device",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES): bool,
-                    vol.Required(CONF_ENTRY_SETTINGS_EQ_SELECTOR): bool,
-                    vol.Required(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR): bool,
-                    vol.Required(CONF_ENTRY_SETTINGS_WOOFER_NUMBER): bool,
+                    vol.Required(CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES, default=False): bool,
+                    vol.Required(CONF_ENTRY_SETTINGS_EQ_SELECTOR, default=False): bool,
+                    vol.Required(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR, default=False): bool,
+                    vol.Required(CONF_ENTRY_SETTINGS_WOOFER_NUMBER, default=False): bool,
                 }
             ),
         )

--- a/custom_components/samsung_soundbar/config_flow.py
+++ b/custom_components/samsung_soundbar/config_flow.py
@@ -48,6 +48,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_device(self, user_input: dict[str, Any] | None = None):
+        # `fetch_failed` in the UI is often caused by exceptions inside the flow.
+        # Be defensive: flows can be resumed and `self.user_input` might not exist.
+        if not hasattr(self, "user_input") or self.user_input is None:
+            self.user_input = {}
+
         if user_input is not None:
             self.user_input.update(user_input)
 
@@ -95,7 +100,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     ),
                     errors={"base": "cannot_connect"},
                 )
-            return self.async_create_entry(title=DOMAIN, data=self.user_input)
+            # Use the device label/name as the entry title if possible (nicer UI).
+            title = None
+            if isinstance(device, dict):
+                title = device.get("label") or device.get("name")
+            return self.async_create_entry(title=title or DOMAIN, data=self.user_input)
 
         return self.async_show_form(
             step_id="device",

--- a/custom_components/samsung_soundbar/config_flow.py
+++ b/custom_components/samsung_soundbar/config_flow.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from aiohttp import ClientResponseError
 import voluptuous as vol
 from homeassistant import config_entries
 from voluptuous import All, Range
@@ -59,8 +60,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.debug(
                     f"Successfully validated Input, Creating entry with title {DOMAIN} and data {user_input}"
                 )
-            except Exception as excp:
-                _LOGGER.exception("Config flow validation failed")
+            except ClientResponseError as excp:
+                _LOGGER.exception("Config flow validation failed (HTTP %s)", excp.status)
+                if excp.status == 401:
+                    base_error = "invalid_auth"
+                elif excp.status == 404:
+                    base_error = "invalid_device"
+                else:
+                    base_error = "cannot_connect"
                 # Keep the user on the same step with a useful base error.
                 return self.async_show_form(
                     step_id="device",
@@ -72,7 +79,21 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             vol.Required(CONF_ENTRY_SETTINGS_WOOFER_NUMBER, default=self.user_input.get(CONF_ENTRY_SETTINGS_WOOFER_NUMBER, False)): bool,
                         }
                     ),
-                    errors={"base": "fetch_failed"},
+                    errors={"base": base_error},
+                )
+            except Exception:
+                _LOGGER.exception("Config flow validation failed")
+                return self.async_show_form(
+                    step_id="device",
+                    data_schema=vol.Schema(
+                        {
+                            vol.Required(CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES, default=self.user_input.get(CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES, False)): bool,
+                            vol.Required(CONF_ENTRY_SETTINGS_EQ_SELECTOR, default=self.user_input.get(CONF_ENTRY_SETTINGS_EQ_SELECTOR, False)): bool,
+                            vol.Required(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR, default=self.user_input.get(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR, False)): bool,
+                            vol.Required(CONF_ENTRY_SETTINGS_WOOFER_NUMBER, default=self.user_input.get(CONF_ENTRY_SETTINGS_WOOFER_NUMBER, False)): bool,
+                        }
+                    ),
+                    errors={"base": "cannot_connect"},
                 )
             return self.async_create_entry(title=DOMAIN, data=self.user_input)
 

--- a/custom_components/samsung_soundbar/const.py
+++ b/custom_components/samsung_soundbar/const.py
@@ -24,4 +24,4 @@ SELECT = SELECT_DOMAIN
 SUPPORTED_DOMAINS = ["media_player", "switch"]
 
 
-PLATFORMS = [SWITCH, MEDIA_PLAYER, SELECT, BUTTON]
+PLATFORMS = ["media_player", "sensor", "select", "button", "switch", "number", "image"]

--- a/custom_components/samsung_soundbar/coordinator.py
+++ b/custom_components/samsung_soundbar/coordinator.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api_extension.SoundbarDevice import SoundbarDevice
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+DEFAULT_UPDATE_INTERVAL = timedelta(seconds=10)
+
+
+class SoundbarCoordinator(DataUpdateCoordinator[SoundbarDevice]):
+    def __init__(self, hass: HomeAssistant, device: SoundbarDevice) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_{device.device_id}",
+            update_interval=DEFAULT_UPDATE_INTERVAL,
+        )
+        self._device = device
+
+    async def _async_update_data(self) -> SoundbarDevice:
+        try:
+            await self._device.update()
+            return self._device
+        except Exception as err:
+            raise UpdateFailed(str(err)) from err
+

--- a/custom_components/samsung_soundbar/image.py
+++ b/custom_components/samsung_soundbar/image.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from datetime import datetime
 
@@ -5,6 +7,7 @@ from homeassistant.components.image import ImageEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.typing import UndefinedType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api_extension.SoundbarDevice import SoundbarDevice
 from .const import CONF_ENTRY_DEVICE_ID, DOMAIN
@@ -15,51 +18,48 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     domain_data = hass.data[DOMAIN]
+    entities: list[ImageEntity] = []
 
-    entities = []
     for key in domain_data.devices:
         device_config: DeviceConfig = domain_data.devices[key]
         device = device_config.device
-        if device.device_id == config_entry.data.get(CONF_ENTRY_DEVICE_ID):
-            entities.append(SoundbarImageEntity(device, "Image URL", hass))
+        coordinator = device_config.coordinator
+        if device.device_id != config_entry.data.get(CONF_ENTRY_DEVICE_ID):
+            continue
+        entities.append(SoundbarCoverArtImage(coordinator, hass))
+
     async_add_entities(entities)
     return True
 
 
-class SoundbarImageEntity(ImageEntity):
-    def __init__(
-        self, device: SoundbarDevice, append_unique_id: str, hass: HomeAssistant
-    ):
-        super().__init__(hass)
-        self.entity_id = f"image.{device.device_name}_{append_unique_id}"
+class SoundbarCoverArtImage(CoordinatorEntity, ImageEntity):
+    def __init__(self, coordinator, hass: HomeAssistant) -> None:
+        CoordinatorEntity.__init__(self, coordinator)
+        ImageEntity.__init__(self, hass)
 
-        self.__device = device
-        self._attr_unique_id = f"{device.device_id}_sw_{append_unique_id}"
+        dev: SoundbarDevice = coordinator.data
+        self._attr_unique_id = f"{dev.device_id}_cover_art"
+        self._attr_name = "Cover Art"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.__device.device_id)},
-            name=self.__device.device_name,
-            manufacturer=self.__device.manufacturer,
-            model=self.__device.model,
-            sw_version=self.__device.firmware_version,
+            identifiers={(DOMAIN, dev.device_id)},
+            name=dev.device_name,
+            manufacturer=dev.manufacturer,
+            model=dev.model,
+            sw_version=dev.firmware_version,
         )
+        self.__updated: datetime | None = None
 
-        self.__updated = None
-
-    # ---------- GENERAL ---------------
     @property
     def image_url(self) -> str | None | UndefinedType:
-        """Return URL of image."""
-        return self.__device.media_coverart_url
+        dev: SoundbarDevice = self.coordinator.data
+        return dev.media_coverart_url
 
     @property
     def image_last_updated(self) -> datetime | None:
-        """The time when the image was last updated."""
-        current = self.__device.media_coverart_updated
+        dev: SoundbarDevice = self.coordinator.data
+        current = dev.media_coverart_updated
         if self.__updated != current:
             self._cached_image = None
             self.__updated = current
         return current
 
-    @property
-    def name(self):
-        return self.__device.device_name

--- a/custom_components/samsung_soundbar/manifest.json
+++ b/custom_components/samsung_soundbar/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/samuelspagl/ha_samsung_soundbar/issues",
-  "requirements": ["pysmartthings"],
-  "version": "0.4.0"
+  "requirements": [],
+  "version": "0.5.0"
 }

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from typing import Any, Mapping
 
 from homeassistant.components.media_player import MediaPlayerEntity
@@ -136,6 +137,31 @@ def addServices():
             {vol.Required("uri"): str, vol.Optional("level"): vol.All(int, vol.Range(min=0, max=100))}
         ),
         SmartThingsSoundbarMediaPlayer.async_play_track_and_resume.__name__,
+    )
+
+    platform.async_register_entity_service(
+        "execute_set",
+        cv.make_entity_service_schema(
+            {
+                vol.Required("href"): str,
+                vol.Required("property"): str,
+                # Accept JSON as string for UI friendliness; we parse it in code.
+                vol.Required("value"): str,
+            }
+        ),
+        SmartThingsSoundbarMediaPlayer.async_execute_set.__name__,
+    )
+
+    platform.async_register_entity_service(
+        "ocf_post",
+        cv.make_entity_service_schema(
+            {
+                vol.Required("href"): str,
+                # JSON object as string
+                vol.Required("value"): str,
+            }
+        ),
+        SmartThingsSoundbarMediaPlayer.async_ocf_post.__name__,
     )
 
 
@@ -373,6 +399,26 @@ class SmartThingsSoundbarMediaPlayer(CoordinatorEntity[SoundbarCoordinator], Med
     async def async_play_track_and_resume(self, uri: str, level: int | None = None):
         args = [uri] if level is None else [uri, level]
         await self.device.device.command("main", "audioNotification", "playTrackAndResume", args)
+        await self.coordinator.async_request_refresh()
+
+    async def async_execute_set(self, href: str, property: str, value: str):
+        # Parse JSON if possible, otherwise treat as plain string.
+        parsed: Any
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            parsed = value
+        await self.device.execute_set_raw(href, property, parsed)
+        await self.coordinator.async_request_refresh()
+
+    async def async_ocf_post(self, href: str, value: str):
+        try:
+            parsed = json.loads(value)
+        except Exception as exc:
+            raise ValueError("ocf_post value must be JSON object string") from exc
+        if not isinstance(parsed, dict):
+            raise ValueError("ocf_post value must be a JSON object")
+        await self.device.ocf_post(href, parsed)
         await self.coordinator.async_request_refresh()
 
     # This property can be uncommented for some extra_attributes

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -1,15 +1,21 @@
 import logging
 from typing import Any, Mapping
 
-from homeassistant.components.media_player import (
-    DEVICE_CLASS_SPEAKER,
-    MediaPlayerEntity,
-)
+from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import MediaPlayerEntityFeature
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo, generate_entity_id
 from homeassistant.helpers import config_validation as cv, entity_platform, selector
 import voluptuous as vol
+
+# NOTE:
+# Home Assistant removed DEVICE_CLASS_SPEAKER from newer versions, which caused an
+# ImportError and prevented the integration from loading. Keep compatibility with
+# both old and new HA versions by falling back to the canonical string value.
+try:
+    from homeassistant.components.media_player import DEVICE_CLASS_SPEAKER
+except ImportError:  # pragma: no cover - depends on HA version
+    DEVICE_CLASS_SPEAKER = "speaker"
 
 from .api_extension.SoundbarDevice import SoundbarDevice
 from .api_extension.const import SpeakerIdentifier, RearSpeakerMode

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -217,14 +217,8 @@ class SmartThingsSoundbarMediaPlayer(CoordinatorEntity[SoundbarCoordinator], Med
         if not (self.source_list or []):
             features &= ~MediaPlayerEntityFeature.SELECT_SOURCE
 
-        # Only advertise playback controls if the underlying device supports them.
-        # Newer OCF soundbars often do not expose media playback capabilities.
-        if hasattr(self.device.device, "play"):
-            features |= MediaPlayerEntityFeature.PLAY
-        if hasattr(self.device.device, "pause"):
-            features |= MediaPlayerEntityFeature.PAUSE
-        if hasattr(self.device.device, "stop"):
-            features |= MediaPlayerEntityFeature.STOP
+        # Newer OCF soundbars often do not expose media playback capabilities, so we don't
+        # advertise PLAY/PAUSE/STOP unless explicitly added later.
         return features
 
     @property
@@ -383,22 +377,19 @@ class SmartThingsSoundbarMediaPlayer(CoordinatorEntity[SoundbarCoordinator], Med
 
     async def async_set_sound_from(self, mode: int, detail_name: str | None = None):
         args = [mode] if not detail_name else [mode, detail_name]
-        await self.device.device.command("main", "samsungvd.soundFrom", "setSoundFrom", args)
+        await self.device.command("samsungvd.soundFrom", "setSoundFrom", args)
         await self.coordinator.async_request_refresh()
 
     async def async_play_track(self, uri: str, level: int | None = None):
-        args = [uri] if level is None else [uri, level]
-        await self.device.device.command("main", "audioNotification", "playTrack", args)
+        await self.device.play_track(uri, level)
         await self.coordinator.async_request_refresh()
 
     async def async_play_track_and_restore(self, uri: str, level: int | None = None):
-        args = [uri] if level is None else [uri, level]
-        await self.device.device.command("main", "audioNotification", "playTrackAndRestore", args)
+        await self.device.play_track_and_restore(uri, level)
         await self.coordinator.async_request_refresh()
 
     async def async_play_track_and_resume(self, uri: str, level: int | None = None):
-        args = [uri] if level is None else [uri, level]
-        await self.device.device.command("main", "audioNotification", "playTrackAndResume", args)
+        await self.device.play_track_and_resume(uri, level)
         await self.coordinator.async_request_refresh()
 
     async def async_execute_set(self, href: str, property: str, value: str):

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -3,9 +3,9 @@ from typing import Any, Mapping
 
 from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import MediaPlayerEntityFeature
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.entity import DeviceInfo, generate_entity_id
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers import config_validation as cv, entity_platform, selector
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 import voluptuous as vol
 
 # NOTE:
@@ -27,6 +27,7 @@ from .const import (
     DOMAIN,
 )
 from .models import DeviceConfig
+from .coordinator import SoundbarCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -110,6 +111,38 @@ def addServices():
         SmartThingsSoundbarMediaPlayer.async_set_space_fit_sound.__name__,
     )
 
+    platform.async_register_entity_service(
+        "set_sound_from",
+        cv.make_entity_service_schema(
+            {vol.Required("mode"): int, vol.Optional("detail_name"): str}
+        ),
+        SmartThingsSoundbarMediaPlayer.async_set_sound_from.__name__,
+    )
+
+    platform.async_register_entity_service(
+        "play_track",
+        cv.make_entity_service_schema(
+            {vol.Required("uri"): str, vol.Optional("level"): vol.All(int, vol.Range(min=0, max=100))}
+        ),
+        SmartThingsSoundbarMediaPlayer.async_play_track.__name__,
+    )
+
+    platform.async_register_entity_service(
+        "play_track_and_restore",
+        cv.make_entity_service_schema(
+            {vol.Required("uri"): str, vol.Optional("level"): vol.All(int, vol.Range(min=0, max=100))}
+        ),
+        SmartThingsSoundbarMediaPlayer.async_play_track_and_restore.__name__,
+    )
+
+    platform.async_register_entity_service(
+        "play_track_and_resume",
+        cv.make_entity_service_schema(
+            {vol.Required("uri"): str, vol.Optional("level"): vol.All(int, vol.Range(min=0, max=100))}
+        ),
+        SmartThingsSoundbarMediaPlayer.async_play_track_and_resume.__name__,
+    )
+
 
 
 
@@ -121,24 +154,20 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     entities = []
     for key in domain_data.devices:
         device_config: DeviceConfig = domain_data.devices[key]
-        session = async_get_clientsession(hass)
         device = device_config.device
+        coordinator: SoundbarCoordinator = device_config.coordinator
         if device.device_id == config_entry.data.get(CONF_ENTRY_DEVICE_ID):
-            entity_id = generate_entity_id(
-                "media_player.{}", device.device_name, hass=hass
-            )
-            entities.append(SmartThingsSoundbarMediaPlayer(device, entity_id, session))
+            entities.append(SmartThingsSoundbarMediaPlayer(coordinator))
     async_add_entities(entities)
     return True
 
 
-class SmartThingsSoundbarMediaPlayer(MediaPlayerEntity):
-    def __init__(self, device: SoundbarDevice, entity_id: str, session):
-        self.session = session
-        self.device = device
-        self.entity_id = entity_id
-        self._attr_unique_id = f"{self.device.device_id}_mp"
-
+class SmartThingsSoundbarMediaPlayer(CoordinatorEntity[SoundbarCoordinator], MediaPlayerEntity):
+    def __init__(self, coordinator: SoundbarCoordinator):
+        super().__init__(coordinator)
+        self.device: SoundbarDevice = coordinator.data
+        self._attr_unique_id = f"{self.device.device_id}_media_player"
+        self._attr_name = self.device.device_name
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.device.device_id)},
             name=self.device.device_name,
@@ -147,8 +176,9 @@ class SmartThingsSoundbarMediaPlayer(MediaPlayerEntity):
             sw_version=self.device.firmware_version,
         )
 
-    async def async_update(self):
-        await self.device.update()
+    @property
+    def available(self) -> bool:
+        return super().available and self.coordinator.last_update_success
 
     # ---------- GENERAL SETTINGS ------------
 
@@ -158,7 +188,14 @@ class SmartThingsSoundbarMediaPlayer(MediaPlayerEntity):
 
     @property
     def supported_features(self):
-        return SUPPORT_SMARTTHINGS_SOUNDBAR
+        features = SUPPORT_SMARTTHINGS_SOUNDBAR
+        # Don't advertise sound mode selection if we don't have a list.
+        if not (self.sound_mode_list or []):
+            features &= ~MediaPlayerEntityFeature.SELECT_SOUND_MODE
+        # We can still select source via cycling if supportedInputSources exists.
+        if not (self.source_list or []):
+            features &= ~MediaPlayerEntityFeature.SELECT_SOURCE
+        return features
 
     @property
     def name(self):
@@ -172,9 +209,11 @@ class SmartThingsSoundbarMediaPlayer(MediaPlayerEntity):
 
     async def async_turn_off(self):
         await self.device.switch_off()
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self):
         await self.device.switch_on()
+        await self.coordinator.async_request_refresh()
 
     # ---------- VOLUME ------------
     @property
@@ -187,15 +226,19 @@ class SmartThingsSoundbarMediaPlayer(MediaPlayerEntity):
 
     async def async_set_volume_level(self, volume):
         await self.device.set_volume(volume)
+        await self.coordinator.async_request_refresh()
 
     async def async_mute_volume(self, mute):
         await self.device.mute_volume(mute)
+        await self.coordinator.async_request_refresh()
 
     async def async_volume_up(self):
         await self.device.volume_up()
+        await self.coordinator.async_request_refresh()
 
     async def async_volume_down(self):
         await self.device.volume_down()
+        await self.coordinator.async_request_refresh()
 
     # ---------- INPUT SOURCES ------------
 
@@ -209,6 +252,7 @@ class SmartThingsSoundbarMediaPlayer(MediaPlayerEntity):
 
     async def async_select_source(self, source):
         await self.device.select_source(source)
+        await self.coordinator.async_request_refresh()
 
     # ---------- SOUND MODE ------------
 
@@ -222,6 +266,7 @@ class SmartThingsSoundbarMediaPlayer(MediaPlayerEntity):
 
     async def async_select_sound_mode(self, sound_mode):
         await self.device.select_sound_mode(sound_mode)
+        await self.coordinator.async_request_refresh()
 
     # ---------- MEDIA ------------
     @property
@@ -250,32 +295,41 @@ class SmartThingsSoundbarMediaPlayer(MediaPlayerEntity):
 
     async def async_media_play(self):
         await self.device.media_play()
+        await self.coordinator.async_request_refresh()
 
     async def async_media_pause(self):
         await self.device.media_pause()
+        await self.coordinator.async_request_refresh()
 
     async def async_media_next_track(self):
         await self.device.media_next_track()
+        await self.coordinator.async_request_refresh()
 
     async def async_media_previous_track(self):
         await self.device.media_previous_track()
+        await self.coordinator.async_request_refresh()
 
     async def async_media_stop(self):
         await self.device.media_stop()
+        await self.coordinator.async_request_refresh()
 
     # ---------- SERVICE_UTILITY ------------
 
     async def async_set_woofer_level(self, level: int):
         await self.device.set_woofer(level)
+        await self.coordinator.async_request_refresh()
 
     async def async_set_bass_mode(self, enabled: bool):
         await self.device.set_bass_mode(enabled)
+        await self.coordinator.async_request_refresh()
 
     async def async_set_voice_mode(self, enabled: bool):
         await self.device.set_voice_amplifier(enabled)
+        await self.coordinator.async_request_refresh()
 
     async def async_set_night_mode(self, enabled: bool):
         await self.device.set_night_mode(enabled)
+        await self.coordinator.async_request_refresh()
 
     # ---------- SERVICE_UTILITY ------------
 
@@ -283,15 +337,39 @@ class SmartThingsSoundbarMediaPlayer(MediaPlayerEntity):
         await self.device.set_speaker_level(
             SpeakerIdentifier(speaker_identifier), level
         )
+        await self.coordinator.async_request_refresh()
 
     async def async_set_rear_speaker_mode(self, speaker_mode: str):
         await self.device.set_rear_speaker_mode(RearSpeakerMode(speaker_mode))
+        await self.coordinator.async_request_refresh()
 
     async def async_set_active_voice_amplifier(self, enabled: bool):
         await self.device.set_active_voice_amplifier(enabled)
+        await self.coordinator.async_request_refresh()
 
     async def async_set_space_fit_sound(self, enabled: bool):
         await self.device.set_space_fit_sound(enabled)
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_sound_from(self, mode: int, detail_name: str | None = None):
+        args = [mode] if not detail_name else [mode, detail_name]
+        await self.device.device.command("main", "samsungvd.soundFrom", "setSoundFrom", args)
+        await self.coordinator.async_request_refresh()
+
+    async def async_play_track(self, uri: str, level: int | None = None):
+        args = [uri] if level is None else [uri, level]
+        await self.device.device.command("main", "audioNotification", "playTrack", args)
+        await self.coordinator.async_request_refresh()
+
+    async def async_play_track_and_restore(self, uri: str, level: int | None = None):
+        args = [uri] if level is None else [uri, level]
+        await self.device.device.command("main", "audioNotification", "playTrackAndRestore", args)
+        await self.coordinator.async_request_refresh()
+
+    async def async_play_track_and_resume(self, uri: str, level: int | None = None):
+        args = [uri] if level is None else [uri, level]
+        await self.device.device.command("main", "audioNotification", "playTrackAndResume", args)
+        await self.coordinator.async_request_refresh()
 
     # This property can be uncommented for some extra_attributes
     # Still enabling this can cause side-effects.

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -35,17 +35,12 @@ DEFAULT_NAME = "SmartThings Soundbar"
 CONF_MAX_VOLUME = "max_volume"
 
 SUPPORT_SMARTTHINGS_SOUNDBAR = (
-    MediaPlayerEntityFeature.PAUSE
-    | MediaPlayerEntityFeature.VOLUME_STEP
+    MediaPlayerEntityFeature.VOLUME_STEP
     | MediaPlayerEntityFeature.VOLUME_MUTE
     | MediaPlayerEntityFeature.VOLUME_SET
     | MediaPlayerEntityFeature.SELECT_SOURCE
     | MediaPlayerEntityFeature.TURN_OFF
     | MediaPlayerEntityFeature.TURN_ON
-    | MediaPlayerEntityFeature.PLAY
-    | MediaPlayerEntityFeature.NEXT_TRACK
-    | MediaPlayerEntityFeature.PREVIOUS_TRACK
-    | MediaPlayerEntityFeature.STOP
     | MediaPlayerEntityFeature.SELECT_SOUND_MODE
 )
 
@@ -195,6 +190,15 @@ class SmartThingsSoundbarMediaPlayer(CoordinatorEntity[SoundbarCoordinator], Med
         # We can still select source via cycling if supportedInputSources exists.
         if not (self.source_list or []):
             features &= ~MediaPlayerEntityFeature.SELECT_SOURCE
+
+        # Only advertise playback controls if the underlying device supports them.
+        # Newer OCF soundbars often do not expose media playback capabilities.
+        if hasattr(self.device.device, "play"):
+            features |= MediaPlayerEntityFeature.PLAY
+        if hasattr(self.device.device, "pause"):
+            features |= MediaPlayerEntityFeature.PAUSE
+        if hasattr(self.device.device, "stop"):
+            features |= MediaPlayerEntityFeature.STOP
         return features
 
     @property

--- a/custom_components/samsung_soundbar/models.py
+++ b/custom_components/samsung_soundbar/models.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass
 
-from pysmartthings import SmartThings
-
 from .api_extension.SoundbarDevice import SoundbarDevice
 from .coordinator import SoundbarCoordinator
+from .smartthings_api import SmartThingsApi
 
 
 @dataclass
@@ -15,5 +14,5 @@ class DeviceConfig:
 
 @dataclass
 class SoundbarConfig:
-    api: SmartThings
+    api: SmartThingsApi
     devices: dict

--- a/custom_components/samsung_soundbar/models.py
+++ b/custom_components/samsung_soundbar/models.py
@@ -3,12 +3,14 @@ from dataclasses import dataclass
 from pysmartthings import SmartThings
 
 from .api_extension.SoundbarDevice import SoundbarDevice
+from .coordinator import SoundbarCoordinator
 
 
 @dataclass
 class DeviceConfig:
     config: dict
     device: SoundbarDevice
+    coordinator: SoundbarCoordinator
 
 
 @dataclass

--- a/custom_components/samsung_soundbar/number.py
+++ b/custom_components/samsung_soundbar/number.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from homeassistant.components.number import (
@@ -6,6 +8,7 @@ from homeassistant.components.number import (
     NumberMode,
 )
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api_extension.SoundbarDevice import SoundbarDevice
 from .const import CONF_ENTRY_DEVICE_ID, CONF_ENTRY_SETTINGS_WOOFER_NUMBER, DOMAIN
@@ -16,61 +19,58 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     domain_data = hass.data[DOMAIN]
+    entities: list[NumberEntity] = []
 
-    entities = []
     for key in domain_data.devices:
         device_config: DeviceConfig = domain_data.devices[key]
         device = device_config.device
-        if device.device_id == config_entry.data.get(
-            CONF_ENTRY_DEVICE_ID
-        ) and config_entry.data.get(CONF_ENTRY_SETTINGS_WOOFER_NUMBER):
-            entities.append(
-                SoundbarWooferNumberEntity(
-                    device,
-                    "woofer_level",
-                )
-            )
+        coordinator = device_config.coordinator
+
+        if device.device_id != config_entry.data.get(CONF_ENTRY_DEVICE_ID):
+            continue
+
+        if config_entry.data.get(CONF_ENTRY_SETTINGS_WOOFER_NUMBER):
+            entities.append(WooferLevelNumber(coordinator))
+
     async_add_entities(entities)
     return True
 
 
-class SoundbarWooferNumberEntity(NumberEntity):
-    def __init__(
-        self,
-        device: SoundbarDevice,
-        append_unique_id: str,
-    ):
-        self.entity_id = f"number.{device.device_name}_{append_unique_id}"
-        self.entity_description = NumberEntityDescription(
-            native_max_value=6,
-            native_min_value=-10,
-            mode=NumberMode.BOX,
-            native_step=1,
-            native_unit_of_measurement="dB",
-            key=append_unique_id,
-        )
-        self.__device = device
-        self._attr_unique_id = f"{device.device_id}_sw_{append_unique_id}"
+class WooferLevelNumber(CoordinatorEntity, NumberEntity):
+    entity_description = NumberEntityDescription(
+        key="woofer_level",
+        native_min_value=-12,
+        native_max_value=6,
+        native_step=1,
+        native_unit_of_measurement="dB",
+        mode=NumberMode.BOX,
+    )
+
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        dev: SoundbarDevice = coordinator.data
+
+        self._attr_unique_id = f"{dev.device_id}_woofer_level"
+        self._attr_name = "Woofer Level"
+        self._attr_icon = "mdi:subwoofer"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.__device.device_id)},
-            name=self.__device.device_name,
-            manufacturer=self.__device.manufacturer,
-            model=self.__device.model,
-            sw_version=self.__device.firmware_version,
+            identifiers={(DOMAIN, dev.device_id)},
+            name=dev.device_name,
+            manufacturer=dev.manufacturer,
+            model=dev.model,
+            sw_version=dev.firmware_version,
         )
-        self.__append_unique_id = append_unique_id
-
-    # ---------- GENERAL ---------------
-
-    @property
-    def name(self):
-        return self.__append_unique_id
-
-    # ------ STATE FUNCTIONS --------
 
     @property
     def native_value(self) -> float | None:
-        return self.__device.woofer_level
+        dev: SoundbarDevice = self.coordinator.data
+        try:
+            return float(dev.woofer_level)
+        except Exception:
+            return None
 
     async def async_set_native_value(self, value: float):
-        await self.__device.set_woofer(int(value))
+        dev: SoundbarDevice = self.coordinator.data
+        await dev.set_woofer(int(value))
+        await self.coordinator.async_request_refresh()
+

--- a/custom_components/samsung_soundbar/select.py
+++ b/custom_components/samsung_soundbar/select.py
@@ -1,12 +1,10 @@
+from __future__ import annotations
+
 import logging
 
-from homeassistant.components.number import (
-    NumberEntity,
-    NumberEntityDescription,
-    NumberMode,
-)
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api_extension.SoundbarDevice import SoundbarDevice
 from .const import (
@@ -22,168 +20,119 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     domain_data = hass.data[DOMAIN]
-    entities = []
+    entities: list[SelectEntity] = []
+
     for key in domain_data.devices:
         device_config: DeviceConfig = domain_data.devices[key]
         device = device_config.device
-        if device.device_id == config_entry.data.get(CONF_ENTRY_DEVICE_ID):
-            if config_entry.data.get(CONF_ENTRY_SETTINGS_EQ_SELECTOR):
-                entities.append(
-                    EqPresetSelectEntity(device, "eq_preset", "mdi:tune-vertical")
-                )
-            if config_entry.data.get(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR):
-                entities.append(
-                    SoundModeSelectEntity(
-                        device, "sound_mode_preset", "mdi:surround-sound"
-                    )
-                )
+        coordinator = device_config.coordinator
+        if device.device_id != config_entry.data.get(CONF_ENTRY_DEVICE_ID):
+            continue
 
-            entities.append(
-                InputSelectEntity(device, "input_preset", "mdi:video-input-hdmi")
-            )
+        entities.append(InputSourceSelectEntity(coordinator))
+
+        if config_entry.data.get(CONF_ENTRY_SETTINGS_EQ_SELECTOR):
+            entities.append(EqPresetSelectEntity(coordinator))
+
+        if config_entry.data.get(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR):
+            entities.append(SoundModeSelectEntity(coordinator))
+
     async_add_entities(entities)
     return True
 
 
-class EqPresetSelectEntity(SelectEntity):
-    def __init__(
-        self,
-        device: SoundbarDevice,
-        append_unique_id: str,
-        icon_string: str,
-    ):
-        self.entity_id = f"number.{device.device_name}_{append_unique_id}"
-        self.entity_description = SelectEntityDescription(
-            key=append_unique_id,
-        )
-        self.__base_icon = icon_string
-        self.__device = device
-        self._attr_unique_id = f"{device.device_id}_sw_{append_unique_id}"
+class _BaseSelect(CoordinatorEntity, SelectEntity):
+    def __init__(self, coordinator, desc: SelectEntityDescription, key: str, name: str, icon: str):
+        super().__init__(coordinator)
+        dev: SoundbarDevice = coordinator.data
+
+        self.entity_description = desc
+        self._attr_unique_id = f"{dev.device_id}_{key}"
+        self._attr_name = name
+        self._attr_icon = icon
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.__device.device_id)},
-            name=self.__device.device_name,
-            manufacturer=self.__device.manufacturer,
-            model=self.__device.model,
-            sw_version=self.__device.firmware_version,
+            identifiers={(DOMAIN, dev.device_id)},
+            name=dev.device_name,
+            manufacturer=dev.manufacturer,
+            model=dev.model,
+            sw_version=dev.firmware_version,
         )
-        self.__append_unique_id = append_unique_id
 
-        self._attr_options = self.__device.supported_equalizer_presets
 
-    # ---------- GENERAL ---------------
-
-    @property
-    def name(self):
-        return self.__append_unique_id
-
-    @property
-    def icon(self) -> str | None:
-        return self.__base_icon
-
-    # ------ STATE FUNCTIONS --------
+class InputSourceSelectEntity(_BaseSelect):
+    def __init__(self, coordinator):
+        super().__init__(
+            coordinator,
+            SelectEntityDescription(key="input_source"),
+            key="select_input_source",
+            name="Input Source",
+            icon="mdi:video-input-hdmi",
+        )
 
     @property
     def current_option(self) -> str | None:
-        """Get the current status of the select entity from device_status."""
-        return self.__device.active_equalizer_preset
+        dev: SoundbarDevice = self.coordinator.data
+        return dev.input_source
+
+    @property
+    def options(self) -> list[str]:
+        dev: SoundbarDevice = self.coordinator.data
+        return list(dev.supported_input_sources or [])
 
     async def async_select_option(self, option: str) -> None:
-        """Set the option."""
+        dev: SoundbarDevice = self.coordinator.data
+        await dev.select_source(option)
+        await self.coordinator.async_request_refresh()
 
-        await self.__device.set_equalizer_preset(option)
 
-
-class SoundModeSelectEntity(SelectEntity):
-    def __init__(
-        self,
-        device: SoundbarDevice,
-        append_unique_id: str,
-        icon_string: str,
-    ):
-        self.entity_id = f"number.{device.device_name}_{append_unique_id}"
-        self.entity_description = SelectEntityDescription(
-            key=append_unique_id,
+class EqPresetSelectEntity(_BaseSelect):
+    def __init__(self, coordinator):
+        super().__init__(
+            coordinator,
+            SelectEntityDescription(key="eq_preset"),
+            key="select_eq_preset",
+            name="EQ Preset",
+            icon="mdi:tune-vertical",
         )
-        self.__base_icon = icon_string
-        self.__device = device
-        self._attr_unique_id = f"{device.device_id}_sw_{append_unique_id}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.__device.device_id)},
-            name=self.__device.device_name,
-            manufacturer=self.__device.manufacturer,
-            model=self.__device.model,
-            sw_version=self.__device.firmware_version,
-        )
-        self.__append_unique_id = append_unique_id
-
-        self._attr_options = self.__device.supported_soundmodes
-
-    # ---------- GENERAL ---------------
-
-    @property
-    def name(self):
-        return self.__append_unique_id
-
-    @property
-    def icon(self) -> str | None:
-        return self.__base_icon
-
-    # ------ STATE FUNCTIONS --------
 
     @property
     def current_option(self) -> str | None:
-        """Get the current status of the select entity from device_status."""
-        return self.__device.sound_mode
+        dev: SoundbarDevice = self.coordinator.data
+        return dev.active_equalizer_preset
+
+    @property
+    def options(self) -> list[str]:
+        dev: SoundbarDevice = self.coordinator.data
+        return list(dev.supported_equalizer_presets or [])
 
     async def async_select_option(self, option: str) -> None:
-        """Set the option."""
+        dev: SoundbarDevice = self.coordinator.data
+        await dev.set_equalizer_preset(option)
+        await self.coordinator.async_request_refresh()
 
-        await self.__device.select_sound_mode(option)
 
-
-class InputSelectEntity(SelectEntity):
-    def __init__(
-        self,
-        device: SoundbarDevice,
-        append_unique_id: str,
-        icon_string: str,
-    ):
-        self.entity_id = f"number.{device.device_name}_{append_unique_id}"
-        self.entity_description = SelectEntityDescription(
-            key=append_unique_id,
+class SoundModeSelectEntity(_BaseSelect):
+    def __init__(self, coordinator):
+        super().__init__(
+            coordinator,
+            SelectEntityDescription(key="sound_mode"),
+            key="select_sound_mode",
+            name="Sound Mode",
+            icon="mdi:surround-sound",
         )
-        self.__base_icon = icon_string
-        self.__device = device
-        self._attr_unique_id = f"{device.device_id}_sw_{append_unique_id}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.__device.device_id)},
-            name=self.__device.device_name,
-            manufacturer=self.__device.manufacturer,
-            model=self.__device.model,
-            sw_version=self.__device.firmware_version,
-        )
-        self.__append_unique_id = append_unique_id
-
-        self._attr_options = self.__device.supported_input_sources
-
-    # ---------- GENERAL ---------------
-
-    @property
-    def name(self):
-        return self.__append_unique_id
-
-    @property
-    def icon(self) -> str | None:
-        return self.__base_icon
-
-    # ------ STATE FUNCTIONS --------
 
     @property
     def current_option(self) -> str | None:
-        """Get the current status of the select entity from device_status."""
-        return self.__device.input_source
+        dev: SoundbarDevice = self.coordinator.data
+        return dev.sound_mode
+
+    @property
+    def options(self) -> list[str]:
+        dev: SoundbarDevice = self.coordinator.data
+        return list(dev.supported_soundmodes or [])
 
     async def async_select_option(self, option: str) -> None:
-        """Set the option."""
+        dev: SoundbarDevice = self.coordinator.data
+        await dev.select_sound_mode(option)
+        await self.coordinator.async_request_refresh()
 
-        await self.__device.select_source(option)

--- a/custom_components/samsung_soundbar/sensor.py
+++ b/custom_components/samsung_soundbar/sensor.py
@@ -1,11 +1,12 @@
-import logging
+from __future__ import annotations
 
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorEntity,
-    SensorStateClass,
-)
+from dataclasses import dataclass
+import logging
+from typing import Any, Callable
+
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api_extension.SoundbarDevice import SoundbarDevice
 from .const import CONF_ENTRY_DEVICE_ID, DOMAIN
@@ -14,43 +15,176 @@ from .models import DeviceConfig
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True, slots=True)
+class _SensorSpec:
+    key: str
+    name: str
+    icon: str | None
+    value: Callable[[SoundbarDevice], Any]
+    attrs: Callable[[SoundbarDevice], dict[str, Any]] | None = None
+    enabled_by_default: bool = True
+
+
+def _attrs_from(device: SoundbarDevice, keys: list[str]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for k in keys:
+        v = device._attr(k)  # pylint: disable=protected-access
+        if v is not None:
+            out[k] = v
+    return out
+
+
+SENSORS: list[_SensorSpec] = [
+    _SensorSpec(
+        key="volume_percent",
+        name="Volume",
+        icon="mdi:volume-high",
+        value=lambda d: int((d.volume_level or 0) * 100),
+        attrs=lambda d: {"max_volume": d.max_volume},
+    ),
+    _SensorSpec(
+        key="input_source",
+        name="Input Source",
+        icon="mdi:video-input-hdmi",
+        value=lambda d: d.input_source,
+        attrs=lambda d: {"supported_input_sources": d.supported_input_sources},
+    ),
+    _SensorSpec(
+        key="thing_status",
+        name="Thing Status",
+        icon="mdi:information",
+        value=lambda d: d._attr("status"),
+        attrs=lambda d: {"updated_time": d._attr("updatedTime")},
+    ),
+    _SensorSpec(
+        key="sound_from_mode",
+        name="Sound From Mode",
+        icon="mdi:speaker",
+        value=lambda d: d._attr("mode"),
+        attrs=lambda d: {"detailName": d._attr("detailName")},
+        enabled_by_default=False,
+    ),
+    _SensorSpec(
+        key="ocf_model",
+        name="Model",
+        icon="mdi:identifier",
+        value=lambda d: d.model,
+        attrs=lambda d: _attrs_from(
+            d,
+            [
+                "mnmo",  # model (ex: HW-Q990D)
+                "mnfv",  # firmware
+                "mnos",  # OS (ex: Tizen)
+                "mnpv",  # OS version
+                "vid",
+                "dmv",
+                "icv",
+                "mndt",
+            ],
+        ),
+    ),
+    _SensorSpec(
+        key="supported_features",
+        name="Supported Features",
+        icon="mdi:feature-search",
+        value=lambda d: d._attr("wifiUpdateSupport"),
+        attrs=lambda d: _attrs_from(
+            d,
+            [
+                "wifiUpdateSupport",
+                "artSupported",
+                "executableServiceList",
+                "imeAdvSupported",
+                "mediaOutputSupported",
+                "mobileCamSupported",
+                "remotelessSupported",
+            ],
+        ),
+        enabled_by_default=False,
+    ),
+    _SensorSpec(
+        key="wifi_configuration",
+        name="WiFi Configuration",
+        icon="mdi:wifi-cog",
+        value=lambda d: d._attr("autoReconnection"),
+        attrs=lambda d: _attrs_from(
+            d,
+            [
+                "autoReconnection",
+                "supportedAuthType",
+                "supportedWiFiFreq",
+                "protocolType",
+                "minVersion",
+            ],
+        ),
+        enabled_by_default=False,
+    ),
+    _SensorSpec(
+        key="diagnostics_information",
+        name="Diagnostics Information",
+        icon="mdi:tools",
+        value=lambda d: d._attr("endpoint"),
+        attrs=lambda d: _attrs_from(
+            d,
+            [
+                "endpoint",
+                "dumpType",
+                "logType",
+                "protocolType",
+                "setupId",
+                "mnId",
+                "tsId",
+                "minVersion",
+            ],
+        ),
+        enabled_by_default=False,
+    ),
+]
+
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
     domain_data = hass.data[DOMAIN]
-    entities = []
+    entities: list[SoundbarSensor] = []
+
     for key in domain_data.devices:
         device_config: DeviceConfig = domain_data.devices[key]
         device = device_config.device
+        coordinator = device_config.coordinator
+        if device.device_id != config_entry.data.get(CONF_ENTRY_DEVICE_ID):
+            continue
+        for spec in SENSORS:
+            entities.append(SoundbarSensor(coordinator, spec))
 
-        if device.device_id == config_entry.data.get(CONF_ENTRY_DEVICE_ID):
-            entities.append(VolumeSensor(device, "volume_level", "mdi:volume-high"))
     async_add_entities(entities)
     return True
 
 
-class VolumeSensor(SensorEntity):
-    def __init__(self, device: SoundbarDevice, append_unique_id: str, icon_string: str):
-        self.entity_id = f"sensor.{device.device_name}_{append_unique_id}"
-        self.__device = device
-        self._attr_unique_id = f"{device.device_id}_sw_{append_unique_id}"
-        self.__base_icon = icon_string
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.__device.device_id)},
-            name=self.__device.device_name,
-            manufacturer=self.__device.manufacturer,
-            model=self.__device.model,
-            sw_version=self.__device.firmware_version,
-        )
-        self.__append_unique_id = append_unique_id
+class SoundbarSensor(CoordinatorEntity, SensorEntity):
+    def __init__(self, coordinator, spec: _SensorSpec) -> None:
+        super().__init__(coordinator)
+        self._spec = spec
+        dev: SoundbarDevice = coordinator.data
 
-        _attr_device_class = SensorDeviceClass.VOLUME
+        self._attr_unique_id = f"{dev.device_id}_{spec.key}"
+        self._attr_name = spec.name
+        self._attr_icon = spec.icon
+        self._attr_entity_registry_enabled_default = spec.enabled_by_default
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, dev.device_id)},
+            name=dev.device_name,
+            manufacturer=dev.manufacturer,
+            model=dev.model,
+            sw_version=dev.firmware_version,
+        )
 
     @property
-    def icon(self) -> str | None:
-        return self.__base_icon
+    def native_value(self):
+        dev: SoundbarDevice = self.coordinator.data
+        return self._spec.value(dev)
 
-    def update(self) -> None:
-        """Fetch new state data for the sensor.
-
-        This is the only method that should fetch new data for Home Assistant.
-        """
-        self._attr_native_value = self.__device.device.status.volume
+    @property
+    def extra_state_attributes(self):
+        if not self._spec.attrs:
+            return None
+        dev: SoundbarDevice = self.coordinator.data
+        return self._spec.attrs(dev)

--- a/custom_components/samsung_soundbar/services.yaml
+++ b/custom_components/samsung_soundbar/services.yaml
@@ -165,3 +165,95 @@ set_space_fit_sound:
       default: false
       selector:
         boolean:
+
+set_sound_from:
+  name: Set Sound From
+  description: Set the SamsungVD soundFrom mode (raw integer) and optional detail name.
+  target:
+    device:
+      integration: samsung_soundbar
+  fields:
+    mode:
+      name: Mode
+      required: true
+      example: 4
+      selector:
+        number:
+          min: 0
+          max: 20
+          step: 1
+    detail_name:
+      name: Detail Name
+      required: false
+      example: "HDMI"
+      selector:
+        text:
+
+play_track:
+  name: Play Track
+  description: Play an audio track URI on the soundbar.
+  target:
+    device:
+      integration: samsung_soundbar
+  fields:
+    uri:
+      name: URI
+      required: true
+      example: "https://example.com/sound.mp3"
+      selector:
+        text:
+    level:
+      name: Level
+      required: false
+      example: 30
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+
+play_track_and_restore:
+  name: Play Track And Restore
+  description: Play an audio track URI on the soundbar and restore the previous state.
+  target:
+    device:
+      integration: samsung_soundbar
+  fields:
+    uri:
+      name: URI
+      required: true
+      example: "https://example.com/sound.mp3"
+      selector:
+        text:
+    level:
+      name: Level
+      required: false
+      example: 30
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+
+play_track_and_resume:
+  name: Play Track And Resume
+  description: Play an audio track URI on the soundbar and resume playback afterwards.
+  target:
+    device:
+      integration: samsung_soundbar
+  fields:
+    uri:
+      name: URI
+      required: true
+      example: "https://example.com/sound.mp3"
+      selector:
+        text:
+    level:
+      name: Level
+      required: false
+      example: 30
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1

--- a/custom_components/samsung_soundbar/services.yaml
+++ b/custom_components/samsung_soundbar/services.yaml
@@ -257,3 +257,49 @@ play_track_and_resume:
           min: 0
           max: 100
           step: 1
+
+execute_set:
+  name: Execute Set (Raw)
+  description: Power-user service to call execute with a raw href/property/value.
+  target:
+    device:
+      integration: samsung_soundbar
+  fields:
+    href:
+      name: Href
+      required: true
+      example: "/sec/networkaudio/woofer"
+      selector:
+        text:
+    property:
+      name: Property
+      required: true
+      example: "x.com.samsung.networkaudio.woofer"
+      selector:
+        text:
+    value:
+      name: Value (JSON or string)
+      required: true
+      example: "3"
+      selector:
+        text:
+
+ocf_post:
+  name: OCF Post (Raw)
+  description: Power-user service to call ocf.postOcfCommand with a raw href and JSON object.
+  target:
+    device:
+      integration: samsung_soundbar
+  fields:
+    href:
+      name: Href
+      required: true
+      example: "/sec/networkaudio/advancedaudio"
+      selector:
+        text:
+    value:
+      name: Value (JSON object)
+      required: true
+      example: "{\"key\":\"value\"}"
+      selector:
+        text:

--- a/custom_components/samsung_soundbar/smartthings_api.py
+++ b/custom_components/samsung_soundbar/smartthings_api.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+_LOGGER = logging.getLogger(__name__)
+
+
+API_BASE = "https://api.smartthings.com/v1"
+
+
+class SmartThingsApi:
+    def __init__(self, hass, token: str):
+        self._hass = hass
+        self._token = token
+        self._session = async_get_clientsession(hass)
+
+    @property
+    def token(self) -> str:
+        return self._token
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._token}", "Accept": "application/json"}
+
+    async def get(self, path: str) -> dict[str, Any]:
+        url = f"{API_BASE}{path}"
+        async with self._session.get(url, headers=self._headers()) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+    async def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        url = f"{API_BASE}{path}"
+        async with self._session.post(url, headers=self._headers() | {"Content-Type": "application/json"}, json=payload) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+    async def get_device(self, device_id: str) -> dict[str, Any]:
+        return await self.get(f"/devices/{device_id}")
+
+    async def get_status(self, device_id: str) -> dict[str, Any]:
+        return await self.get(f"/devices/{device_id}/status")
+
+    async def send_commands(self, device_id: str, commands: list[dict[str, Any]]) -> dict[str, Any]:
+        return await self.post(f"/devices/{device_id}/commands", {"commands": commands})

--- a/custom_components/samsung_soundbar/switch.py
+++ b/custom_components/samsung_soundbar/switch.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 import logging
+from typing import Awaitable, Callable
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api_extension.SoundbarDevice import SoundbarDevice
 from .const import (
@@ -16,98 +20,95 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     domain_data = hass.data[DOMAIN]
+    entities: list[SwitchEntity] = []
 
-    entities = []
     for key in domain_data.devices:
         device_config: DeviceConfig = domain_data.devices[key]
         device = device_config.device
-        if device.device_id == config_entry.data.get(CONF_ENTRY_DEVICE_ID):
-            if config_entry.data.get(CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES):
-                entities.append(
-                    SoundbarSwitchAdvancedAudio(
-                        device,
-                        "nightmode",
-                        lambda: device.night_mode,
-                        device.set_night_mode,
-                        device.set_night_mode,
-                        "mdi:weather-night",
-                    )
-                )
-                entities.append(
-                    SoundbarSwitchAdvancedAudio(
-                        device,
-                        "bassmode",
-                        lambda: device.bass_mode,
-                        device.set_bass_mode,
-                        device.set_bass_mode,
-                        "mdi:speaker-wireless",
-                    )
-                )
-                entities.append(
-                    SoundbarSwitchAdvancedAudio(
-                        device,
-                        "voice_amplifier",
-                        lambda: device.voice_amplifier,
-                        device.set_voice_amplifier,
-                        device.set_voice_amplifier,
-                        "mdi:account-voice",
-                    )
-                )
+        coordinator = device_config.coordinator
+
+        if device.device_id != config_entry.data.get(CONF_ENTRY_DEVICE_ID):
+            continue
+
+        if config_entry.data.get(CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES):
+            entities.extend(
+                [
+                    SoundbarBoolSwitch(
+                        coordinator,
+                        key="night_mode",
+                        name="Night Mode",
+                        icon="mdi:weather-night",
+                        getter=lambda d: d.night_mode,
+                        setter=lambda d, v: d.set_night_mode(v),
+                    ),
+                    SoundbarBoolSwitch(
+                        coordinator,
+                        key="bass_boost",
+                        name="Bass Boost",
+                        icon="mdi:speaker-wireless",
+                        getter=lambda d: d.bass_mode,
+                        setter=lambda d, v: d.set_bass_mode(v),
+                    ),
+                    SoundbarBoolSwitch(
+                        coordinator,
+                        key="voice_amplifier",
+                        name="Voice Amplifier",
+                        icon="mdi:account-voice",
+                        getter=lambda d: d.voice_amplifier,
+                        setter=lambda d, v: d.set_voice_amplifier(v),
+                    ),
+                ]
+            )
+
     async_add_entities(entities)
     return True
 
 
-class SoundbarSwitchAdvancedAudio(SwitchEntity):
+class SoundbarBoolSwitch(CoordinatorEntity, SwitchEntity):
     def __init__(
         self,
-        device: SoundbarDevice,
-        append_unique_id: str,
-        state_function,
-        on_function,
-        off_function,
-        icon_string: str = "mdi:toggle-switch-variant",
-    ):
-        self.entity_id = f"switch.{device.device_name}_{append_unique_id}"
+        coordinator,
+        *,
+        key: str,
+        name: str,
+        icon: str,
+        getter: Callable[[SoundbarDevice], bool],
+        setter: Callable[[SoundbarDevice, bool], Awaitable[None]],
+    ) -> None:
+        super().__init__(coordinator)
+        self._key = key
+        self._getter = getter
+        self._setter = setter
 
-        self.__device = device
-        self._name = f"{self.__device.device_name} {append_unique_id}"
-        self._attr_unique_id = f"{device.device_id}_sw_{append_unique_id}"
-        self.__base_icon = icon_string
+        dev: SoundbarDevice = coordinator.data
+        self._attr_unique_id = f"{dev.device_id}_{key}"
+        self._attr_name = name
+        self._attr_icon = icon
+        # For newer models execute/status may be unavailable, so treat as assumed state.
+        self._attr_assumed_state = True
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.__device.device_id)},
-            name=self.__device.device_name,
-            manufacturer=self.__device.manufacturer,
-            model=self.__device.model,
-            sw_version=self.__device.firmware_version,
+            identifiers={(DOMAIN, dev.device_id)},
+            name=dev.device_name,
+            manufacturer=dev.manufacturer,
+            model=dev.model,
+            sw_version=dev.firmware_version,
         )
 
-        self.__state_function = state_function
-        self.__state = False
-        self.__on_function = on_function
-        self.__off_function = off_function
-
-    # ---------- GENERAL ---------------
-
     @property
-    def name(self):
-        return self._name
+    def is_on(self) -> bool | None:
+        dev: SoundbarDevice = self.coordinator.data
+        try:
+            return bool(self._getter(dev))
+        except Exception:
+            return None
 
-    def update(self):
-        self.__state = self.__state_function()
+    async def async_turn_on(self, **kwargs):
+        dev: SoundbarDevice = self.coordinator.data
+        await self._setter(dev, True)
+        await self.coordinator.async_request_refresh()
 
-    @property
-    def icon(self) -> str | None:
-        return self.__base_icon
+    async def async_turn_off(self, **kwargs):
+        dev: SoundbarDevice = self.coordinator.data
+        await self._setter(dev, False)
+        await self.coordinator.async_request_refresh()
 
-    # ------ STATE FUNCTIONS --------
-    @property
-    def state(self):
-        return "on" if self.__state else "off"
-
-    async def async_turn_off(self):
-        await self.__off_function(False)
-        self.__state = "off"
-
-    async def async_turn_on(self):
-        await self.__on_function(True)
-        self.__state = "on"

--- a/custom_components/samsung_soundbar/translations/en.json
+++ b/custom_components/samsung_soundbar/translations/en.json
@@ -1,5 +1,10 @@
 {
     "config": {
+        "error": {
+            "cannot_connect": "Failed to connect to SmartThings. Please try again.",
+            "invalid_auth": "Invalid SmartThings token.",
+            "invalid_device": "Device ID not found in SmartThings for this token."
+        },
         "step": {
             "user": {
                 "data": {


### PR DESCRIPTION
This PR fixes an ImportError on newer Home Assistant versions by adding a try/except fallback for `DEVICE_CLASS_SPEAKER`.

It also improves support for newer Samsung OCF soundbars (ex: HW-Q990D) by:
- Fixing config flow handler loading (ConfigFlow class name)
- Avoiding `pysmartthings.DeviceEntity` import (not exported in newer pysmartthings)
- Passing the SmartThings token from the config entry (no dependency on private pysmartthings internals)
- Using a DataUpdateCoordinator to reduce API calls and rate limits
- Handling empty/null execute status payloads gracefully
- Improving input source handling via `samsungvd.audioInputSource` (cycle using `setNextInputSource`)
- Adding sensors (OCF model/firmware, thing status, input source, WiFi/diagnostics/supportsFeatures)
- Adding audioNotification services (play_track / restore / resume) and samsungvd.soundFrom service
- Fixing mute logic and a woofer update flag typo

Notes:
- Some models return `execute/status` with `data.value = null`, so x.com.samsung.networkaudio.* discovery isn't possible via execute/status. The integration now degrades gracefully and avoids aggressive polling.