### PR TITLE
Comment on PR with pre-release link in deployment workflow

### DIFF
--- a/.github/workflows/pr-deployment.yaml
+++ b/.github/workflows/pr-deployment.yaml
@@ -19,6 +19,9 @@ on:
   issue_comment:
     types:
       - "created"
+  pull_request_review_comment:
+    types:
+      - "created"
 
 permissions: {}
 
@@ -30,6 +33,10 @@ jobs:
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/deploy ')
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
         startsWith(github.event.comment.body, '/deploy ')
       )
     runs-on: "ubuntu-latest"
@@ -48,11 +55,23 @@ jobs:
           INPUT_RELEASE_NAME: "${{ inputs.release_name }}"
           COMMENT_BODY: "${{ github.event.comment.body }}"
           COMMENT_PR_NUMBER: "${{ github.event.issue.number }}"
+          REVIEW_COMMENT_PR_NUMBER: "${{ github.event.pull_request.number }}"
         run: |
           if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             pr_number="${INPUT_PR_NUMBER}"
             tag_name="${INPUT_TAG_NAME}"
             release_name="${INPUT_RELEASE_NAME}"
+          elif [[ "${EVENT_NAME}" == "pull_request_review_comment" ]]; then
+            # Command format: /deploy <tag_name> [release name]
+            cmd="${COMMENT_BODY}"
+            rest="${cmd#/deploy }"
+            tag_name="${rest%% *}"
+            if [[ "${rest}" == "${tag_name}" ]]; then
+              release_name=""
+            else
+              release_name="${rest#* }"
+            fi
+            pr_number="${REVIEW_COMMENT_PR_NUMBER}"
           else
             # Command format: /deploy <tag_name> [release name]
             cmd="${COMMENT_BODY}"

--- a/.github/workflows/pr-deployment.yaml
+++ b/.github/workflows/pr-deployment.yaml
@@ -1,0 +1,69 @@
+name: "PR Deployment"
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull Request Number"
+        required: true
+        type: number
+      tag_name:
+        description: "Tag/Version (z. B. v1.2.3-rc1)"
+        required: true
+        type: string
+      release_name:
+        description: "Release-Name"
+        required: false
+        default: ""
+        type: string
+
+permissions: {}
+
+jobs:
+  deploy:
+    name: "Create pre-release from PR"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: "Checkout PR merge commit"
+        uses: "actions/checkout@v4.1.0"
+        with:
+          ref: "refs/pull/${{ inputs.pr_number }}/merge"
+          fetch-depth: 0
+
+      - name: "Validate tag format"
+        shell: "bash"
+        run: |
+          if [[ ! "${{ inputs.tag_name }}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Tag '${{ inputs.tag_name }}' does not look like a semantic version." >&2
+            exit 1
+          fi
+
+      - name: "Create pre-release"
+        uses: "softprops/action-gh-release@v2"
+        with:
+          tag_name: "${{ inputs.tag_name }}"
+          target_commitish: "${{ github.sha }}"
+          prerelease: true
+          generate_release_notes: true
+          name: "${{ inputs.release_name != '' && inputs.release_name || inputs.tag_name }}"
+          body: |
+            Automated pre-release from PR #${{ inputs.pr_number }}.
+
+      - name: "Comment on PR with release link"
+        uses: "actions/github-script@v7"
+        env:
+          RELEASE_URL: "https://github.com/${{ github.repository }}/releases/tag/${{ inputs.tag_name }}"
+        with:
+          script: |
+            const prNumber = Number('${{ inputs.pr_number }}');
+            const releaseUrl = process.env.RELEASE_URL;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `🚀 Pre-release erstellt: ${releaseUrl}`,
+            });

--- a/.github/workflows/pr-deployment.yaml
+++ b/.github/workflows/pr-deployment.yaml
@@ -33,11 +33,11 @@ jobs:
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        startsWith(github.event.comment.body, '/deploy ')
+        startsWith(github.event.comment.body, '/deploy')
       ) ||
       (
         github.event_name == 'pull_request_review_comment' &&
-        startsWith(github.event.comment.body, '/deploy ')
+        startsWith(github.event.comment.body, '/deploy')
       )
     runs-on: "ubuntu-latest"
     permissions:
@@ -62,26 +62,16 @@ jobs:
             tag_name="${INPUT_TAG_NAME}"
             release_name="${INPUT_RELEASE_NAME}"
           elif [[ "${EVENT_NAME}" == "pull_request_review_comment" ]]; then
-            # Command format: /deploy <tag_name> [release name]
-            cmd="${COMMENT_BODY}"
-            rest="${cmd#/deploy }"
-            tag_name="${rest%% *}"
-            if [[ "${rest}" == "${tag_name}" ]]; then
-              release_name=""
-            else
-              release_name="${rest#* }"
-            fi
+            # Command format: /deploy [release name]
+            tag_name=""
+            release_name="${COMMENT_BODY#/deploy}"
+            release_name="${release_name# }"
             pr_number="${REVIEW_COMMENT_PR_NUMBER}"
           else
-            # Command format: /deploy <tag_name> [release name]
-            cmd="${COMMENT_BODY}"
-            rest="${cmd#/deploy }"
-            tag_name="${rest%% *}"
-            if [[ "${rest}" == "${tag_name}" ]]; then
-              release_name=""
-            else
-              release_name="${rest#* }"
-            fi
+            # Command format: /deploy [release name]
+            tag_name=""
+            release_name="${COMMENT_BODY#/deploy}"
+            release_name="${release_name# }"
             pr_number="${COMMENT_PR_NUMBER}"
           fi
 
@@ -95,29 +85,46 @@ jobs:
           ref: "refs/pull/${{ steps.resolve.outputs.pr_number }}/merge"
           fetch-depth: 0
 
+      - name: "Determine effective tag"
+        id: "effective"
+        shell: "bash"
+        env:
+          RESOLVED_TAG: "${{ steps.resolve.outputs.tag_name }}"
+          PR_NUMBER: "${{ steps.resolve.outputs.pr_number }}"
+          RUN_ID: "${{ github.run_id }}"
+        run: |
+          if [[ -n "${RESOLVED_TAG}" ]]; then
+            tag_name="${RESOLVED_TAG}"
+          else
+            version="$(python -c 'import json; print(json.load(open("custom_components/samsung_soundbar/manifest.json"))["version"])')"
+            tag_name="v${version}-pr${PR_NUMBER}-run${RUN_ID}"
+          fi
+
+          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+
       - name: "Validate tag format"
         shell: "bash"
         run: |
-          if [[ ! "${{ steps.resolve.outputs.tag_name }}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
-            echo "Tag '${{ steps.resolve.outputs.tag_name }}' does not look like a semantic version." >&2
+          if [[ ! "${{ steps.effective.outputs.tag_name }}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Tag '${{ steps.effective.outputs.tag_name }}' does not look like a semantic version." >&2
             exit 1
           fi
 
       - name: "Create pre-release"
         uses: "softprops/action-gh-release@v2"
         with:
-          tag_name: "${{ steps.resolve.outputs.tag_name }}"
+          tag_name: "${{ steps.effective.outputs.tag_name }}"
           target_commitish: "${{ github.sha }}"
           prerelease: true
           generate_release_notes: true
-          name: "${{ steps.resolve.outputs.release_name != '' && steps.resolve.outputs.release_name || steps.resolve.outputs.tag_name }}"
+          name: "${{ steps.resolve.outputs.release_name != '' && steps.resolve.outputs.release_name || steps.effective.outputs.tag_name }}"
           body: |
             Automated pre-release from PR #${{ steps.resolve.outputs.pr_number }}.
 
       - name: "Comment on PR with release link"
         uses: "actions/github-script@v7"
         env:
-          RELEASE_URL: "https://github.com/${{ github.repository }}/releases/tag/${{ steps.resolve.outputs.tag_name }}"
+          RELEASE_URL: "https://github.com/${{ github.repository }}/releases/tag/${{ steps.effective.outputs.tag_name }}"
         with:
           script: |
             const prNumber = Number('${{ steps.resolve.outputs.pr_number }}');

--- a/.github/workflows/pr-deployment.yaml
+++ b/.github/workflows/pr-deployment.yaml
@@ -16,49 +16,92 @@ on:
         required: false
         default: ""
         type: string
+  issue_comment:
+    types:
+      - "created"
 
 permissions: {}
 
 jobs:
   deploy:
     name: "Create pre-release from PR"
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/deploy ')
+      )
     runs-on: "ubuntu-latest"
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
+      - name: "Resolve deployment inputs"
+        id: "resolve"
+        shell: "bash"
+        env:
+          EVENT_NAME: "${{ github.event_name }}"
+          INPUT_PR_NUMBER: "${{ inputs.pr_number }}"
+          INPUT_TAG_NAME: "${{ inputs.tag_name }}"
+          INPUT_RELEASE_NAME: "${{ inputs.release_name }}"
+          COMMENT_BODY: "${{ github.event.comment.body }}"
+          COMMENT_PR_NUMBER: "${{ github.event.issue.number }}"
+        run: |
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            pr_number="${INPUT_PR_NUMBER}"
+            tag_name="${INPUT_TAG_NAME}"
+            release_name="${INPUT_RELEASE_NAME}"
+          else
+            # Command format: /deploy <tag_name> [release name]
+            cmd="${COMMENT_BODY}"
+            rest="${cmd#/deploy }"
+            tag_name="${rest%% *}"
+            if [[ "${rest}" == "${tag_name}" ]]; then
+              release_name=""
+            else
+              release_name="${rest#* }"
+            fi
+            pr_number="${COMMENT_PR_NUMBER}"
+          fi
+
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+          echo "release_name=${release_name}" >> "$GITHUB_OUTPUT"
+
       - name: "Checkout PR merge commit"
         uses: "actions/checkout@v4.1.0"
         with:
-          ref: "refs/pull/${{ inputs.pr_number }}/merge"
+          ref: "refs/pull/${{ steps.resolve.outputs.pr_number }}/merge"
           fetch-depth: 0
 
       - name: "Validate tag format"
         shell: "bash"
         run: |
-          if [[ ! "${{ inputs.tag_name }}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
-            echo "Tag '${{ inputs.tag_name }}' does not look like a semantic version." >&2
+          if [[ ! "${{ steps.resolve.outputs.tag_name }}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Tag '${{ steps.resolve.outputs.tag_name }}' does not look like a semantic version." >&2
             exit 1
           fi
 
       - name: "Create pre-release"
         uses: "softprops/action-gh-release@v2"
         with:
-          tag_name: "${{ inputs.tag_name }}"
+          tag_name: "${{ steps.resolve.outputs.tag_name }}"
           target_commitish: "${{ github.sha }}"
           prerelease: true
           generate_release_notes: true
-          name: "${{ inputs.release_name != '' && inputs.release_name || inputs.tag_name }}"
+          name: "${{ steps.resolve.outputs.release_name != '' && steps.resolve.outputs.release_name || steps.resolve.outputs.tag_name }}"
           body: |
-            Automated pre-release from PR #${{ inputs.pr_number }}.
+            Automated pre-release from PR #${{ steps.resolve.outputs.pr_number }}.
 
       - name: "Comment on PR with release link"
         uses: "actions/github-script@v7"
         env:
-          RELEASE_URL: "https://github.com/${{ github.repository }}/releases/tag/${{ inputs.tag_name }}"
+          RELEASE_URL: "https://github.com/${{ github.repository }}/releases/tag/${{ steps.resolve.outputs.tag_name }}"
         with:
           script: |
-            const prNumber = Number('${{ inputs.pr_number }}');
+            const prNumber = Number('${{ steps.resolve.outputs.pr_number }}');
             const releaseUrl = process.env.RELEASE_URL;
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
### Motivation
- Provide immediate feedback in the PR thread after creating a pre-release by posting a comment with a direct link to the generated release.
- Ensure the workflow has the necessary permissions to create comments on the PR.

### Description
- Update ` .github/workflows/pr-deployment.yaml` to set job permission `pull-requests: write` so the workflow can post comments. 
- Add an `actions/github-script@v7` step that constructs the release URL from `github.repository` and `inputs.tag_name` and comments on the given PR number. 
- Keep the manual `workflow_dispatch` flow and the existing `softprops/action-gh-release@v2` pre-release creation step unchanged.

### Testing
- Ran `git diff -- .github/workflows/pr-deployment.yaml` to inspect the change, which succeeded. 
- Attempted `yq e '.' .github/workflows/pr-deployment.yaml >/dev/null && echo OK`, but `yq` is not installed in the environment so that validation was skipped. 
- Committed the updated workflow with `git commit -m "Comment on PR with pre-release link"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f35c49bd4832ea3e2b75ee03b8b1f)