### PR TITLE
Add actor authorization gate to PR deployment workflow

### DIFF
--- a/.github/workflows/pr-deployment.yaml
+++ b/.github/workflows/pr-deployment.yaml
@@ -79,6 +79,42 @@ jobs:
           echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
           echo "release_name=${release_name}" >> "$GITHUB_OUTPUT"
 
+      # Authorization policy:
+      # - Users who invoke this workflow (manual dispatch or /deploy comments) must have
+      #   at least write-level repository permission.
+      # - Allowed levels are: write, maintain, admin.
+      # - We prefer github.triggering_actor when available so workflow re-runs are checked
+      #   against the user who clicked re-run instead of the original actor.
+      # This gate blocks all downstream checkout/tag/release steps when unauthorized.
+      - name: "Authorize deployment actor"
+        id: "authorize"
+        uses: "actions/github-script@v7"
+        env:
+          REQUESTED_BY: "${{ github.triggering_actor != '' && github.triggering_actor || github.actor }}"
+        with:
+          script: |
+            const allowedPermissions = new Set(['write', 'maintain', 'admin']);
+            const requestedBy = process.env.REQUESTED_BY;
+
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: requestedBy,
+            });
+
+            const permission = data.permission;
+            core.info(`Deployment requested by '${requestedBy}' with '${permission}' permission.`);
+
+            if (!allowedPermissions.has(permission)) {
+              core.setFailed(
+                `Deployment denied for @${requestedBy}: repository permission '${permission}' is below required level. ` +
+                `Allowed permissions: ${Array.from(allowedPermissions).join(', ')}.`
+              );
+              return;
+            }
+
+            core.info(`Authorization gate passed for @${requestedBy}.`);
+
       - name: "Checkout PR merge commit"
         uses: "actions/checkout@v4.1.0"
         with:


### PR DESCRIPTION
### Motivation

- Prevent unauthorized users from triggering the PR deployment flow by enforcing a minimum repository permission level before any checkout/tag/release actions run.
- Ensure consistent behavior for manual runs, issue/review comment triggers, and re-runs by checking the effective invoking user.

### Description

- Inserted an early `Authorize deployment actor` step immediately after `Resolve deployment inputs` that runs `actions/github-script@v7` to query the invoker's permission via `repos.getCollaboratorPermissionLevel`.
- Enforces a minimum allowed permission set (`write`, `maintain`, `admin`) and calls `core.setFailed` with a clear denial message when the actor's permission is below the threshold, which blocks downstream checkout/tag/release steps.
- Uses `github.triggering_actor` when available with a fallback to `github.actor` so re-runs are validated against the user who actually triggered the run.
- Adds workflow comments documenting the authorization policy and allowed roles so maintainers understand who can invoke deployments and why failures occur.

### Testing

- Parsed the updated workflow YAML successfully using Ruby with `YAML.load_file` which returned `YAML parse OK`.
- Attempted YAML parsing in Python but the check failed because `PyYAML` was not available in the environment (`No module named 'yaml'`).
- Confirmed the workflow file is syntactically valid according to the Ruby YAML loader and that the new `Authorize deployment actor` step is present and syntactically correct in the workflow file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f493d8e2c832e85e4820a8c6f7283)