### PR TITLE
docs: add quick sanity-check tip to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Welcome to YASSI, the Home Assistant integration designed to bring comprehensive control over your Samsung Soundbar into your smart home ecosystem.
 
+> [!TIP]
+> Looking for a quick sanity check after setup? Try toggling **night mode** once from Home Assistant to confirm commands are reaching your soundbar.
+
 > [!NOTE]
 > Please use service calls for setting the attribute of a custom capability instead of the entity. (See #43 for more information)
 


### PR DESCRIPTION
### Motivation
- Add a brief, visible tip in `README.md` to help users verify integration commands reach the soundbar after setup by toggling night mode.

### Description
- Inserted a `[!TIP]` callout near the top of `README.md` recommending toggling **night mode** once from Home Assistant as a quick sanity check.

### Testing
- No automated tests were required for this documentation-only change; validation consisted of updating `README.md` and confirming the file contents were updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f4bfd1558832e98159b768496223d)