### PR TITLE
Fix PR deployment workflow to produce release artifacts

### DIFF
--- a/.github/workflows/pr-deployment.yaml
+++ b/.github/workflows/pr-deployment.yaml
@@ -157,6 +157,18 @@ jobs:
           body: |
             Automated pre-release from PR #${{ steps.resolve.outputs.pr_number }}.
 
+      - name: "Package integration"
+        shell: "bash"
+        run: |
+          cd "${{ github.workspace }}/custom_components/samsung_soundbar"
+          zip -r samsung_soundbar.zip ./
+
+      - name: "Attach integration package to pre-release"
+        uses: "softprops/action-gh-release@v2"
+        with:
+          tag_name: "${{ steps.effective.outputs.tag_name }}"
+          files: "${{ github.workspace }}/custom_components/samsung_soundbar/samsung_soundbar.zip"
+
       - name: "Comment on PR with release link"
         uses: "actions/github-script@v7"
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - "published"
+      - "prereleased"
 
 permissions: {}
 


### PR DESCRIPTION
### Motivation
- Ensure creating a pre-release from a PR also produces and publishes the integration artifact so consumers can download a packaged build.
- Ensure the release pipeline reacts to pre-release events so uploaded artifacts are handled consistently for pre-releases as well as published releases.

### Description
- Added a `Package integration` step to `.github/workflows/pr-deployment.yaml` that zips `custom_components/samsung_soundbar` into `samsung_soundbar.zip`.
- Added an `Attach integration package to pre-release` step to `.github/workflows/pr-deployment.yaml` that uploads the generated `samsung_soundbar.zip` to the pre-release using `softprops/action-gh-release@v2` and the resolved `tag_name`.
- Updated `.github/workflows/release.yaml` to also trigger on `prereleased` events in addition to `published` so the release workflow runs for pre-releases.

### Testing
- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pr-deployment.yaml'); YAML.load_file('.github/workflows/release.yaml'); puts 'YAML OK'"` which succeeded and validated both workflow files as YAML.
- Attempted `python` YAML load with `PyYAML` which failed because `PyYAML` is not installed in this environment.
- Attempted `yq` validation which failed because `yq` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f4d8e0d00832e960228b43c2c2473)