### PR TITLE
Use OAuth2 Application Credentials and SmartThings client; replace SoundbarDevice implementation

### DIFF
--- a/custom_components/samsung_soundbar/__init__.py
+++ b/custom_components/samsung_soundbar/__init__.py
@@ -34,22 +34,26 @@ async def _async_get_access_token(hass: HomeAssistant, entry: ConfigEntry) -> st
     return oauth_session.token[CONF_ACCESS_TOKEN]
 
 
+async def _async_get_authenticated_client(hass: HomeAssistant, entry: ConfigEntry) -> SmartThings:
+    token = await _async_get_access_token(hass, entry)
+    api = SmartThings(session=async_get_clientsession(hass))
+    api.authenticate(token)
+    return api
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up component from a config entry, config_entry contains data from config entry database."""
     _LOGGER.info("[%s] Starting to setup a ConfigEntry", DOMAIN)
     _LOGGER.debug("[%s] Setting up ConfigEntry with the following data: %s", DOMAIN, entry.data)
 
-    token = await _async_get_access_token(hass, entry)
+    api = await _async_get_authenticated_client(hass, entry)
 
     if DOMAIN not in hass.data:
         _LOGGER.debug("[%s] Domain not found in hass.data setting default", DOMAIN)
-        hass.data[DOMAIN] = SoundbarConfig(
-            SmartThings(async_get_clientsession(hass), token),
-            {},
-        )
+        hass.data[DOMAIN] = SoundbarConfig(api, {})
 
     domain_config: SoundbarConfig = hass.data[DOMAIN]
-    domain_config.api.token = token
+    domain_config.api = api
     _LOGGER.debug("[%s] Retrieved Domain Config: %s", DOMAIN, domain_config)
 
     options = {**DEFAULT_OPTIONS, **entry.options}
@@ -61,7 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             DOMAIN,
             entry.data.get(CONF_ENTRY_DEVICE_ID),
         )
-        smart_things_device = await domain_config.api.device(entry.data.get(CONF_ENTRY_DEVICE_ID))
+        smart_things_device = await domain_config.api.get_device(entry.data.get(CONF_ENTRY_DEVICE_ID))
         session = async_get_clientsession(hass)
 
         soundbar_device = SoundbarDevice(

--- a/custom_components/samsung_soundbar/__init__.py
+++ b/custom_components/samsung_soundbar/__init__.py
@@ -1,13 +1,14 @@
 import logging
-
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import DOMAIN, HomeAssistant
+from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from pysmartthings import SmartThings
 
 from .api_extension.SoundbarDevice import SoundbarDevice
+from .config_flow import DEFAULT_OPTIONS
 from .const import (
-    CONF_ENTRY_API_KEY,
     CONF_ENTRY_DEVICE_ID,
     CONF_ENTRY_DEVICE_NAME,
     CONF_ENTRY_MAX_VOLUME,
@@ -16,7 +17,6 @@ from .const import (
     CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR,
     CONF_ENTRY_SETTINGS_WOOFER_NUMBER,
     DOMAIN,
-    SUPPORTED_DOMAINS,
 )
 from .models import DeviceConfig, SoundbarConfig
 
@@ -25,54 +25,64 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["media_player", "switch", "image", "number", "select", "sensor"]
 
 
+async def _async_get_access_token(hass: HomeAssistant, entry: ConfigEntry) -> str:
+    implementation = await config_entry_oauth2_flow.async_get_config_entry_implementation(
+        hass, entry
+    )
+    oauth_session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
+    await oauth_session.async_ensure_token_valid()
+    return oauth_session.token[CONF_ACCESS_TOKEN]
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up component from a config entry, config_entry contains data from config entry database."""
-    # store shell object
+    _LOGGER.info("[%s] Starting to setup a ConfigEntry", DOMAIN)
+    _LOGGER.debug("[%s] Setting up ConfigEntry with the following data: %s", DOMAIN, entry.data)
 
-    _LOGGER.info(f"[{DOMAIN}] Starting to setup a ConfigEntry")
-    _LOGGER.debug(
-        f"[{DOMAIN}] Setting up ConfigEntry with the following data: {entry.data}"
-    )
-    if not DOMAIN in hass.data:
-        _LOGGER.debug(f"[{DOMAIN}] Domain not found in hass.data setting default")
+    token = await _async_get_access_token(hass, entry)
+
+    if DOMAIN not in hass.data:
+        _LOGGER.debug("[%s] Domain not found in hass.data setting default", DOMAIN)
         hass.data[DOMAIN] = SoundbarConfig(
-            SmartThings(
-                async_get_clientsession(hass), entry.data.get(CONF_ENTRY_API_KEY)
-            ),
+            SmartThings(async_get_clientsession(hass), token),
             {},
         )
 
     domain_config: SoundbarConfig = hass.data[DOMAIN]
-    _LOGGER.debug(f"[{DOMAIN}] Retrieved Domain Config: {domain_config}")
+    domain_config.api.token = token
+    _LOGGER.debug("[%s] Retrieved Domain Config: %s", DOMAIN, domain_config)
 
-    if not entry.data.get(CONF_ENTRY_DEVICE_ID) in domain_config.devices:
-        _LOGGER.info(f"[{DOMAIN}] Setting up new Soundbar device")
+    options = {**DEFAULT_OPTIONS, **entry.options}
+
+    if entry.data.get(CONF_ENTRY_DEVICE_ID) not in domain_config.devices:
+        _LOGGER.info("[%s] Setting up new Soundbar device", DOMAIN)
         _LOGGER.debug(
-            f"[{DOMAIN}] DeviceId: {entry.data.get(CONF_ENTRY_DEVICE_ID)} not found in domain_config, setting up new device."
+            "[%s] DeviceId: %s not found in domain_config, setting up new device.",
+            DOMAIN,
+            entry.data.get(CONF_ENTRY_DEVICE_ID),
         )
-        smart_things_device = await domain_config.api.device(
-            entry.data.get(CONF_ENTRY_DEVICE_ID)
-        )
+        smart_things_device = await domain_config.api.device(entry.data.get(CONF_ENTRY_DEVICE_ID))
         session = async_get_clientsession(hass)
+
         soundbar_device = SoundbarDevice(
-            smart_things_device,
-            session,
-            entry.data.get(CONF_ENTRY_MAX_VOLUME),
-            entry.data.get(CONF_ENTRY_DEVICE_NAME),
-            enable_eq=entry.data.get(CONF_ENTRY_SETTINGS_EQ_SELECTOR),
-            enable_advanced_audio=entry.data.get(
-                CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES
-            ),
-            enable_soundmode=entry.data.get(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR),
-            enable_woofer=entry.data.get(CONF_ENTRY_SETTINGS_WOOFER_NUMBER),
+            device=smart_things_device,
+            smartthings=domain_config.api,
+            session=session,
+            max_volume=options.get(CONF_ENTRY_MAX_VOLUME),
+            device_name=entry.data.get(CONF_ENTRY_DEVICE_NAME),
+            enable_eq=options.get(CONF_ENTRY_SETTINGS_EQ_SELECTOR),
+            enable_advanced_audio=options.get(CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES),
+            enable_soundmode=options.get(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR),
+            enable_woofer=options.get(CONF_ENTRY_SETTINGS_WOOFER_NUMBER),
         )
         await soundbar_device.update()
         domain_config.devices[entry.data.get(CONF_ENTRY_DEVICE_ID)] = DeviceConfig(
-            entry.data, soundbar_device
+            {**entry.data, **options}, soundbar_device
         )
-        _LOGGER.info(f"[{DOMAIN}] Successfully initialized new Soundbar device")
+        _LOGGER.info("[%s] Successfully initialized new Soundbar device", DOMAIN)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True
 
 
@@ -86,3 +96,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
             del hass.data[DOMAIN]
 
     return unload_ok
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload config entry when options/token change."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
+++ b/custom_components/samsung_soundbar/api_extension/SoundbarDevice.py
@@ -2,33 +2,51 @@ import asyncio
 import datetime
 import json
 import logging
+import re
+from typing import Any
 from urllib.parse import quote
 
-from pysmartthings import DeviceEntity
+from pysmartthings import Capability, Command, Device, SmartThings
 
-from .const import SpeakerIdentifier, RearSpeakerMode
-from ..const import DOMAIN
+from .const import RearSpeakerMode, SpeakerIdentifier
 
+DOMAIN = "soundbar"
 log = logging.getLogger(__name__)
 
 
 class SoundbarDevice:
     def __init__(
-            self,
-            device: DeviceEntity,
-            session,
-            max_volume: int,
-            device_name: str,
-            enable_eq: bool = False,
-            enable_soundmode: bool = False,
-            enable_advanced_audio: bool = False,
-            enable_woofer: bool = False,
+        self,
+        device: Device,
+        smartthings: SmartThings | None = None,
+        session: Any | None = None,
+        max_volume: int = 100,
+        device_name: str | None = None,
+        enable_eq: bool = False,
+        enable_soundmode: bool = False,
+        enable_advanced_audio: bool = False,
+        enable_woofer: bool = False,
     ):
         self.device = device
         self._device_id = self.device.device_id
-        self._api_key = self.device._api.token
+
+        self.__smartthings = smartthings or getattr(self.device, "_api", None)
+        if self.__smartthings is None:
+            raise ValueError(
+                "SoundbarDevice requires a SmartThings client. "
+                "Pass `smartthings=SmartThings(...)` when using pysmartthings>=3.5."
+            )
+        if not hasattr(self.__smartthings, "get_device_status") or not hasattr(
+            self.__smartthings, "execute_device_command"
+        ):
+            raise TypeError(
+                "Unsupported SmartThings client object. "
+                "Expected methods `get_device_status` and `execute_device_command`."
+            )
+
         self.__session = session
-        self.__device_name = device_name
+        self.__device_name = device_name or self.device.label or self.device.name
+        self.__status_data: dict[str, Any] = {}
 
         self.__enable_soundmode = enable_soundmode
         self.__supported_soundmodes = []
@@ -56,9 +74,36 @@ class SoundbarDevice:
         self.__old_media_title = ""
 
         self.__max_volume = max_volume
+        self.__status_retry_at: datetime.datetime | None = None
+        self.__execute_retry_at: datetime.datetime | None = None
 
     async def update(self):
-        await self.device.status.refresh()
+        now = datetime.datetime.now()
+        if self.__status_retry_at and now < self.__status_retry_at:
+            return
+
+        try:
+            raw_status = await self.__smartthings.get_raw_device_status(self._device_id)
+        except Exception as raw_exc:  # pylint: disable=broad-except
+            log.warning(
+                "[%s] get_raw_device_status failed for %s: %s",
+                DOMAIN,
+                self._device_id,
+                raw_exc,
+            )
+            self.__status_retry_at = datetime.datetime.now() + datetime.timedelta(seconds=3)
+            return
+
+        if isinstance(raw_status, dict) and isinstance(raw_status.get("components"), dict):
+            self.__status_data = raw_status["components"]
+            self.__status_retry_at = None
+        else:
+            retry_delay = self._get_retry_delay_seconds(raw_status)
+            if retry_delay is not None:
+                self.__status_retry_at = datetime.datetime.now() + datetime.timedelta(
+                    seconds=retry_delay
+                )
+            return
 
         await self._update_media()
 
@@ -66,42 +111,190 @@ class SoundbarDevice:
             await self._update_soundmode()
         if self.__enable_advanced_audio:
             await self._update_advanced_audio()
-        if self.__enable_soundmode:
+        if self.__enable_woofer:
             await self._update_woofer()
         if self.__enable_eq:
             await self._update_equalizer()
 
+    def _extract_too_many_requests_delay(self, error: Any) -> float | None:
+        if not isinstance(error, dict):
+            return None
+        if error.get("code") != "TooManyRequestError":
+            return None
+
+        details = error.get("details")
+        if not isinstance(details, list):
+            return 2.0
+
+        for detail in details:
+            if not isinstance(detail, dict):
+                continue
+            message = detail.get("message")
+            if not isinstance(message, str):
+                continue
+            match = re.search(r"retry in (\d+) millis", message)
+            if match:
+                try:
+                    return max(1.0, int(match.group(1)) / 1000.0)
+                except ValueError:
+                    return 2.0
+        return 2.0
+
+    def _get_retry_delay_seconds(self, raw_status: Any) -> float | None:
+        if not isinstance(raw_status, dict):
+            return None
+        return self._extract_too_many_requests_delay(raw_status.get("error"))
+
+    async def _wait_for_execute_payload(
+        self,
+        required_key: str,
+        timeout: float = 30.0,
+        interval: float = 0.5,
+    ) -> dict[str, Any] | None:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while asyncio.get_running_loop().time() < deadline:
+            payload = await self.get_execute_status()
+            if required_key in payload:
+                return payload
+            await asyncio.sleep(interval)
+        return None
+
+    def _get_status_value(
+        self,
+        capability: str,
+        attribute: str,
+        component: str = "main",
+        default: Any = None,
+    ) -> Any:
+        component_status = self.__status_data.get(component, {})
+        capability_status = component_status.get(capability)
+        if not isinstance(capability_status, dict):
+            return default
+
+        status = capability_status.get(attribute)
+        if status is None:
+            return default
+
+        if isinstance(status, dict):
+            value = status.get("value")
+        else:
+            value = getattr(status, "value", None)
+        if value is None:
+            return default
+        return value
+
+    def _get_status_record(
+        self,
+        capability: str,
+        attribute: str,
+        component: str = "main",
+    ) -> dict[str, Any] | None:
+        component_status = self.__status_data.get(component, {})
+        if not isinstance(component_status, dict):
+            return None
+        capability_status = component_status.get(capability)
+        if not isinstance(capability_status, dict):
+            return None
+        status = capability_status.get(attribute)
+        if status is None:
+            return None
+
+        if isinstance(status, dict):
+            return status
+
+        record: dict[str, Any] = {}
+        for key in ("value", "unit", "timestamp", "data"):
+            value = getattr(status, key, None)
+            if value is not None:
+                record[key] = value
+        return record or None
+
+    def _get_status_timestamp(
+        self,
+        capability: str,
+        attribute: str,
+        component: str = "main",
+    ) -> str | None:
+        record = self._get_status_record(capability, attribute, component=component)
+        if not isinstance(record, dict):
+            return None
+        timestamp = record.get("timestamp")
+        if isinstance(timestamp, datetime.datetime):
+            return timestamp.isoformat()
+        if isinstance(timestamp, str):
+            return timestamp
+        return None
+
+    def _find_attribute_value(
+        self, attribute: str, component: str = "main", default: Any = None
+    ) -> Any:
+        component_status = self.__status_data.get(component, {})
+        if not isinstance(component_status, dict):
+            return default
+
+        for capability_status in component_status.values():
+            if not isinstance(capability_status, dict):
+                continue
+            status = capability_status.get(attribute)
+            if status is None:
+                continue
+            if isinstance(status, dict):
+                value = status.get("value")
+            else:
+                value = getattr(status, "value", None)
+            if value is not None:
+                return value
+
+        return default
+
+    def _get_first_status_value(
+        self,
+        capabilities: tuple[str, ...],
+        attribute: str,
+        component: str = "main",
+        default: Any = None,
+    ) -> Any:
+        for capability in capabilities:
+            value = self._get_status_value(
+                capability=capability,
+                attribute=attribute,
+                component=component,
+                default=None,
+            )
+            if value is None:
+                continue
+            if isinstance(value, str) and value == "":
+                continue
+            if isinstance(value, list) and len(value) == 0:
+                continue
+            return value
+        return default
+
     async def _update_media(self):
-        if "audioTrackData" in self.device.status._attributes:
-            self.__media_artist = self.device.status._attributes["audioTrackData"].value[
-                "artist"
-            ]
-            self.__media_title = self.device.status._attributes["audioTrackData"].value[
-                "title"
-            ]
-            if self.__media_title != self.__old_media_title:
-                self.__old_media_title = self.__media_title
-                self.__media_cover_url_update_time = datetime.datetime.now()
-                self.__media_cover_url = await self.get_song_title_artwork(
-                    self.__media_artist, self.__media_title
-                )
+        audio_track = self._get_status_value(
+            Capability.AUDIO_TRACK_DATA, "audioTrackData", default={}
+        )
+        if not isinstance(audio_track, dict):
+            return
+
+        self.__media_artist = audio_track.get("artist", "")
+        self.__media_title = audio_track.get("title", "")
+        if self.__media_title != self.__old_media_title:
+            self.__old_media_title = self.__media_title
+            self.__media_cover_url_update_time = datetime.datetime.now()
+            self.__media_cover_url = await self.get_song_title_artwork(
+                self.__media_artist, self.__media_title
+            )
 
     async def _update_soundmode(self):
         await self.update_execution_data(["/sec/networkaudio/soundmode"])
-        await asyncio.sleep(1)
-        payload = await self.get_execute_status()
-        retry = 0
-        while (
-                "x.com.samsung.networkaudio.supportedSoundmode" not in payload
-                and retry < 10
-        ):
-            await asyncio.sleep(1)
-            payload = await self.get_execute_status()
-            retry += 1
-        if retry == 10:
-            log.error(
-                f"[{DOMAIN}] Error: _update_soundmode exceeded a retry counter of 10"
-            )
+        payload = await self._wait_for_execute_payload(
+            required_key="x.com.samsung.networkaudio.supportedSoundmode",
+            timeout=15.0,
+            interval=1.0,
+        )
+        if payload is None:
+            log.error(f"[{DOMAIN}] Error: _update_soundmode timed out waiting for execute payload")
             return
 
         self.__supported_soundmodes = payload[
@@ -111,55 +304,42 @@ class SoundbarDevice:
 
     async def _update_woofer(self):
         await self.update_execution_data(["/sec/networkaudio/woofer"])
-        await asyncio.sleep(0.1)
-        payload = await self.get_execute_status()
-        retry = 0
-        while "x.com.samsung.networkaudio.woofer" not in payload and retry < 10:
-            await asyncio.sleep(0.2)
-            payload = await self.get_execute_status()
-            retry += 1
-        if retry == 10:
-            log.error(
-                f"[{DOMAIN}] Error: _update_woofer exceeded a retry counter of 10"
-            )
+        payload = await self._wait_for_execute_payload(
+            required_key="x.com.samsung.networkaudio.woofer",
+            timeout=15.0,
+            interval=1,
+        )
+        if payload is None:
+            log.error(f"[{DOMAIN}] Error: _update_woofer timed out waiting for execute payload")
             return
         self.__woofer_level = payload["x.com.samsung.networkaudio.woofer"]
         self.__woofer_connection = payload["x.com.samsung.networkaudio.connection"]
 
     async def _update_equalizer(self):
         await self.update_execution_data(["/sec/networkaudio/eq"])
-        await asyncio.sleep(0.1)
-        payload = await self.get_execute_status()
-        retry = 0
-        while "x.com.samsung.networkaudio.EQname" not in payload and retry < 10:
-            await asyncio.sleep(0.2)
-            payload = await self.get_execute_status()
-            retry += 1
-        if retry == 10:
-            log.error(
-                f"[{DOMAIN}] Error: _update_equalizer exceeded a retry counter of 10"
-            )
+        payload = await self._wait_for_execute_payload(
+            required_key="x.com.samsung.networkaudio.EQname",
+            timeout=15.0,
+            interval=1,
+        )
+        if payload is None:
+            log.error(f"[{DOMAIN}] Error: _update_equalizer timed out waiting for execute payload")
             return
         self.__active_eq_preset = payload["x.com.samsung.networkaudio.EQname"]
-        self.__supported_eq_presets = payload[
-            "x.com.samsung.networkaudio.supportedList"
-        ]
+        self.__supported_eq_presets = payload["x.com.samsung.networkaudio.supportedList"]
         self.__eq_action = payload["x.com.samsung.networkaudio.action"]
         self.__eq_bands = payload["x.com.samsung.networkaudio.EQband"]
 
     async def _update_advanced_audio(self):
         await self.update_execution_data(["/sec/networkaudio/advancedaudio"])
-        await asyncio.sleep(0.1)
-
-        payload = await self.get_execute_status()
-        retry = 0
-        while "x.com.samsung.networkaudio.nightmode" not in payload and retry < 10:
-            await asyncio.sleep(0.2)
-            payload = await self.get_execute_status()
-            retry += 1
-        if retry == 10:
+        payload = await self._wait_for_execute_payload(
+            required_key="x.com.samsung.networkaudio.nightmode",
+            timeout=15.0,
+            interval=1.0,
+        )
+        if payload is None:
             log.error(
-                f"[{DOMAIN}] Error: _update_advanced_audio exceeded a retry counter of 10"
+                f"[{DOMAIN}] Error: _update_advanced_audio timed out waiting for execute payload"
             )
             return
 
@@ -169,21 +349,29 @@ class SoundbarDevice:
 
     @property
     def status(self):
-        return self.device.status
+        return self.__status_data
 
     # ------------ DEVICE INFORMATION ----------
 
     @property
     def manufacturer(self):
-        return self.device.status.ocf_manufacturer_name
+        if self.device.ocf and self.device.ocf.manufacturer_name:
+            return self.device.ocf.manufacturer_name
+        return self._find_attribute_value("manufacturerName")
 
     @property
     def model(self):
-        return self.device.status.ocf_model_number
+        if self.device.ocf and self.device.ocf.model_number:
+            return self.device.ocf.model_number
+        return self._find_attribute_value("modelNumber")
 
     @property
     def firmware_version(self):
-        return self.device.status.ocf_firmware_version
+        if self.device.ocf and self.device.ocf.firmware_version:
+            return self.device.ocf.firmware_version
+        if self.device.hub:
+            return self.device.hub.firmware_version
+        return self._find_attribute_value("firmwareVersion")
 
     @property
     def device_id(self):
@@ -197,34 +385,56 @@ class SoundbarDevice:
 
     @property
     def state(self) -> str:
-        if self.device.status.switch:
-            if self.device.status.playback_status == "playing":
-                return "playing"
-            if self.device.status.playback_status == "paused":
-                return "paused"
-            else:
-                return "on"
+        switch_state = self._get_status_value(Capability.SWITCH, "switch", default="off")
+        if isinstance(switch_state, str):
+            is_on = switch_state.lower() == "on"
         else:
+            is_on = bool(switch_state)
+
+        if not is_on:
             return "off"
 
+        playback_status = self._get_status_value(
+            Capability.MEDIA_PLAYBACK, "playbackStatus", default=""
+        )
+        if playback_status == "playing":
+            return "playing"
+        if playback_status == "paused":
+            return "paused"
+        return "on"
+
     async def switch_off(self):
-        await self.device.switch_off(True)
+        await self.__smartthings.execute_device_command(
+            self._device_id, Capability.SWITCH, Command.OFF
+        )
 
     async def switch_on(self):
-        await self.device.switch_on(True)
+        await self.__smartthings.execute_device_command(
+            self._device_id, Capability.SWITCH, Command.ON
+        )
 
     # ------------ VOLUME --------------
 
     @property
     def volume_level(self) -> float:
-        vol = self.device.status.volume
-        if vol > self.__max_volume:
+        vol = self._get_status_value(Capability.AUDIO_VOLUME, "volume", default=0)
+        try:
+            vol_int = int(vol)
+        except (TypeError, ValueError):
+            return 0.0
+
+        if self.__max_volume <= 0:
+            return 0.0
+        if vol_int > self.__max_volume:
             return 1.0
-        return self.device.status.volume / self.__max_volume
+        return vol_int / self.__max_volume
 
     @property
     def volume_muted(self) -> bool:
-        return self.device.status.mute
+        mute = self._get_status_value(Capability.AUDIO_MUTE, "mute", default=False)
+        if isinstance(mute, str):
+            return mute.lower() in {"muted", "mute", "on", "true", "1"}
+        return bool(mute)
 
     async def set_volume(self, volume: float):
         """
@@ -232,19 +442,28 @@ class SoundbarDevice:
         This respects the max volume and hovers between
         :param volume: between 0 and 1
         """
-        await self.device.set_volume(int(volume * self.__max_volume), True)
+        target = int(volume * self.__max_volume)
+        target = max(0, min(target, self.__max_volume))
+        await self.__smartthings.execute_device_command(
+            self._device_id, Capability.AUDIO_VOLUME, Command.SET_VOLUME, argument=target
+        )
 
     async def mute_volume(self, mute: bool):
-        if mute:
-            await self.device.unmute(True)
-        else:
-            await self.device.mute(True)
+        await self.__smartthings.execute_device_command(
+            self._device_id,
+            Capability.AUDIO_MUTE,
+            Command.MUTE if mute else Command.UNMUTE,
+        )
 
     async def volume_up(self):
-        await self.device.volume_up(True)
+        await self.__smartthings.execute_device_command(
+            self._device_id, Capability.AUDIO_VOLUME, Command.VOLUME_UP
+        )
 
     async def volume_down(self):
-        await self.device.volume_down(True)
+        await self.__smartthings.execute_device_command(
+            self._device_id, Capability.AUDIO_VOLUME, Command.VOLUME_DOWN
+        )
 
     # ------------ WOOFER LEVEL -------------
 
@@ -268,16 +487,66 @@ class SoundbarDevice:
 
     @property
     def input_source(self):
+        source = self._get_first_status_value(
+            (
+                Capability.SAMSUNG_VD_AUDIO_INPUT_SOURCE,
+                Capability.SAMSUNG_VD_MEDIA_INPUT_SOURCE,
+                Capability.MEDIA_INPUT_SOURCE,
+            ),
+            "inputSource",
+            default=None,
+        )
+        if source is not None:
+            return source
         if self.media_app_name in ("AirPlay", "Spotify"):
             return "wifi"
-        return self.device.status.input_source
+        return None
 
     @property
     def supported_input_sources(self):
-        return self.device.status.supported_input_sources
+        return self._get_first_status_value(
+            (
+                Capability.SAMSUNG_VD_AUDIO_INPUT_SOURCE,
+                Capability.SAMSUNG_VD_MEDIA_INPUT_SOURCE,
+                Capability.MEDIA_INPUT_SOURCE,
+            ),
+            "supportedInputSources",
+            default=[],
+        )
 
     async def select_source(self, source: str):
-        await self.device.set_input_source(source, True)
+        main_status = self.__status_data.get("main", {})
+        if isinstance(main_status, dict):
+            if Capability.SAMSUNG_VD_MEDIA_INPUT_SOURCE in main_status:
+                await self.__smartthings.execute_device_command(
+                    self._device_id,
+                    Capability.SAMSUNG_VD_MEDIA_INPUT_SOURCE,
+                    Command.SET_INPUT_SOURCE,
+                    argument=source,
+                )
+                return
+            if Capability.MEDIA_INPUT_SOURCE in main_status:
+                await self.__smartthings.execute_device_command(
+                    self._device_id,
+                    Capability.MEDIA_INPUT_SOURCE,
+                    Command.SET_INPUT_SOURCE,
+                    argument=source,
+                )
+                return
+            if Capability.SAMSUNG_VD_AUDIO_INPUT_SOURCE in main_status:
+                await self.__smartthings.execute_device_command(
+                    self._device_id,
+                    Capability.SAMSUNG_VD_AUDIO_INPUT_SOURCE,
+                    Command.SET_NEXT_INPUT_SOURCE,
+                )
+                return
+
+        await self.__smartthings.execute_device_command(
+            self._device_id,
+            Capability.MEDIA_INPUT_SOURCE,
+            Command.SET_INPUT_SOURCE,
+            argument=source,
+        )
 
     # ------------- SOUND MODE --------------
     @property
@@ -299,7 +568,7 @@ class SoundbarDevice:
 
     @property
     def night_mode(self) -> bool:
-        return True if self.__night_mode == 1 else False
+        return self.__night_mode == 1
 
     async def set_night_mode(self, value: bool):
         await self.set_custom_execution_data(
@@ -311,7 +580,7 @@ class SoundbarDevice:
 
     @property
     def bass_mode(self) -> bool:
-        return True if self.__bass_mode == 1 else False
+        return self.__bass_mode == 1
 
     async def set_bass_mode(self, value: bool):
         await self.set_custom_execution_data(
@@ -323,7 +592,7 @@ class SoundbarDevice:
 
     @property
     def voice_amplifier(self) -> bool:
-        return True if self.__voice_amplifier == 1 else False
+        return self.__voice_amplifier == 1
 
     async def set_voice_amplifier(self, value: bool):
         await self.set_custom_execution_data(
@@ -373,40 +642,59 @@ class SoundbarDevice:
 
     @property
     def media_duration(self) -> int | None:
-        attr = self.device.status.attributes.get("totalTime", None)
-        if attr:
-            return attr.value
+        value = self._get_status_value(Capability.MEDIA_PLAYBACK, "totalTime")
+        if value is None:
+            value = self._find_attribute_value("totalTime")
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
     @property
     def media_position(self) -> int | None:
-        attr = self.device.status.attributes.get("elapsedTime", None)
-        if attr:
-            return attr.value
+        value = self._get_status_value(Capability.MEDIA_PLAYBACK, "elapsedTime")
+        if value is None:
+            value = self._find_attribute_value("elapsedTime")
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
     async def media_play(self):
-        await self.device.play(True)
+        await self.__smartthings.execute_device_command(
+            self._device_id, Capability.MEDIA_PLAYBACK, Command.PLAY
+        )
 
     async def media_pause(self):
-        await self.device.pause(True)
+        await self.__smartthings.execute_device_command(
+            self._device_id, Capability.MEDIA_PLAYBACK, Command.PAUSE
+        )
 
     async def media_stop(self):
-        await self.device.stop(True)
+        await self.__smartthings.execute_device_command(
+            self._device_id, Capability.MEDIA_PLAYBACK, Command.STOP
+        )
 
     async def media_next_track(self):
-        await self.device.command("main", "mediaPlayback", "fastForward")
+        await self.__smartthings.execute_device_command(
+            self._device_id, Capability.MEDIA_PLAYBACK, Command.FAST_FORWARD
+        )
 
     async def media_previous_track(self):
-        await self.device.command("main", "mediaPlayback", "rewind")
+        await self.__smartthings.execute_device_command(
+            self._device_id, Capability.MEDIA_PLAYBACK, Command.REWIND
+        )
 
     @property
     def media_app_name(self):
-        detail_status = self.device.status.attributes.get("detailName", None)
-        if detail_status is not None:
-            return detail_status.value
-        return None
+        return self._find_attribute_value("detailName")
 
     @property
-    def media_coverart_updated(self) -> datetime.datetime:
+    def media_coverart_updated(self) -> datetime.datetime | None:
         return self.__media_cover_url_update_time
 
     # ------------ Speaker Level ----------------
@@ -431,32 +719,95 @@ class SoundbarDevice:
         await self.set_custom_execution_data(
             href="/sec/networkaudio/activeVoiceAmplifier",
             property="x.com.samsung.networkaudio.activeVoiceAmplifier",
-            value=1 if enabled else 0
+            value=1 if enabled else 0,
         )
 
     async def set_space_fit_sound(self, enabled: bool):
         await self.set_custom_execution_data(
             href="/sec/networkaudio/spacefitSound",
             property="x.com.samsung.networkaudio.spacefitSound",
-            value=1 if enabled else 0
+            value=1 if enabled else 0,
         )
 
     # ------------ SUPPORT FUNCTIONS ------------
 
-    async def update_execution_data(self, argument: str):
-        stuff = await self.device.command("main", "execute", "execute", argument)
-        return stuff
+    async def update_execution_data(self, argument: list[str]):
+        await self.__smartthings.execute_device_command(
+            self._device_id,
+            Capability.EXECUTE,
+            Command.EXECUTE,
+            argument=argument,
+        )
 
     async def set_custom_execution_data(self, href: str, property: str, value):
         argument = [href, {property: value}]
-        assert await self.device.command("main", "execute", "execute", argument)
+        await self.__smartthings.execute_device_command(
+            self._device_id,
+            Capability.EXECUTE,
+            Command.EXECUTE,
+            argument=argument,
+        )
 
     async def get_execute_status(self):
-        url = f"https://api.smartthings.com/v1/devices/{self._device_id}/components/main/capabilities/execute/status"
-        request_headers = {"Authorization": "Bearer " + self._api_key}
-        resp = await self.__session.get(url, headers=request_headers)
-        dict_stuff = await resp.json()
-        return dict_stuff["data"]["value"]["payload"]
+        payload: dict[str, Any] = {}
+        get_method = getattr(self.__smartthings, "_get", None)
+        if get_method is None:
+            log.error(
+                "[%s] Error: SmartThings client does not expose `_get` for execute status",
+                DOMAIN,
+            )
+            return payload
+
+        now = datetime.datetime.now()
+        if self.__execute_retry_at and now < self.__execute_retry_at:
+            await asyncio.sleep((self.__execute_retry_at - now).total_seconds())
+
+        raw = await get_method(
+            f"v1/devices/{self._device_id}/components/main/capabilities/execute/status"
+        )
+        try:
+            parsed = json.loads(raw)
+            if not isinstance(parsed, dict):
+                return payload
+
+            error = parsed.get("error")
+            retry_delay = self._extract_too_many_requests_delay(error)
+            if retry_delay is not None:
+                self.__execute_retry_at = datetime.datetime.now() + datetime.timedelta(
+                    seconds=retry_delay
+                )
+                log.warning(
+                    "[%s] Execute status API rate-limited for %s. retrying in %.1fs",
+                    DOMAIN,
+                    self._device_id,
+                    retry_delay,
+                )
+                return payload
+            if isinstance(error, dict):
+                log.warning(
+                    "[%s] Execute status API error for %s: %s",
+                    DOMAIN,
+                    self._device_id,
+                    error,
+                )
+                return payload
+
+            self.__execute_retry_at = None
+
+            data = parsed.get("data")
+            if not isinstance(data, dict):
+                return payload
+
+            value = data.get("value")
+            if not isinstance(value, dict):
+                return payload
+
+            response_payload = value.get("payload")
+            if isinstance(response_payload, dict):
+                payload = response_payload
+        except json.JSONDecodeError:
+            log.error("[%s] Error: Invalid execute status response for %s", DOMAIN, self._device_id)
+        return payload
 
     async def get_song_title_artwork(self, artist: str, title: str) -> str:
         """
@@ -466,18 +817,55 @@ class SoundbarDevice:
         :param title: string
         :return: url as string
         """
+        session = self.__session or getattr(self.__smartthings, "session", None)
+        if session is None:
+            return ""
+
         query_term = f"{artist} {title}"
         url = "https://itunes.apple.com/search?term=%s&media=music&entity=%s" % (
             quote(query_term),
             "musicTrack",
         )
-        resp = await self.__session.get(url)
+        resp = await session.get(url)
         resp_dict = json.loads(await resp.text())
         if len(resp_dict["results"]) != 0:
             return resp_dict["results"][0]["artworkUrl100"]
+        return ""
 
     @property
     def retrieve_data(self):
+        woofer_level = self.woofer_level if self.__enable_woofer else None
+        woofer_connection = self.woofer_connection if self.__enable_woofer else None
+        sound_mode = self.sound_mode if self.__enable_soundmode else None
+        supported_sound_modes = self.supported_soundmodes if self.__enable_soundmode else None
+        night_mode = self.night_mode if self.__enable_advanced_audio else None
+        bass_mode = self.bass_mode if self.__enable_advanced_audio else None
+        voice_amplifier = self.voice_amplifier if self.__enable_advanced_audio else None
+        active_eq_preset = self.active_equalizer_preset if self.__enable_eq else None
+        supported_eq_presets = self.supported_equalizer_presets if self.__enable_eq else None
+        equalizer_action = self.equalizer_action if self.__enable_eq else None
+        equalizer_bands = self.equalizer_bands if self.__enable_eq else None
+        playback_status = self._get_status_value(Capability.MEDIA_PLAYBACK, "playbackStatus")
+        supported_playback_commands = self._get_status_value(
+            Capability.MEDIA_PLAYBACK,
+            "supportedPlaybackCommands",
+            default=[],
+        )
+        available_capabilities = []
+        main_status = self.__status_data.get("main")
+        if isinstance(main_status, dict):
+            available_capabilities = sorted(main_status.keys())
+
+        status_retry_until = (
+            self.__status_retry_at.isoformat() if self.__status_retry_at else None
+        )
+        execute_retry_until = (
+            self.__execute_retry_at.isoformat() if self.__execute_retry_at else None
+        )
+        media_cover_updated = (
+            self.media_coverart_updated.isoformat() if self.media_coverart_updated else None
+        )
+
         return {
             "status": self.state,
             "device_information": {
@@ -485,30 +873,40 @@ class SoundbarDevice:
                 "manufacture": self.manufacturer,
                 "firmware_version": self.firmware_version,
                 "device_id": self.device_id,
+                "name": self.device.name,
+                "label": self.device.label,
+                "type": str(self.device.type),
+                "location_id": self.device.location_id,
+                "room_id": self.device.room_id,
             },
             "volume": {"level": self.volume_level, "muted": self.volume_muted},
             "woofer": {
-                "level": self.woofer_level,
-                "connection": self.woofer_connection,
+                "level": woofer_level,
+                "connection": woofer_connection,
             },
             "source": {
                 "active_source": self.input_source,
                 "supported_sources": self.supported_input_sources,
+                "media_app_name": self.media_app_name,
+            },
+            "playback": {
+                "status": playback_status,
+                "supported_commands": supported_playback_commands,
             },
             "sound_mode": {
-                "active_sound_mode": self.sound_mode,
-                "supported_sound_modes": self.supported_soundmodes,
+                "active_sound_mode": sound_mode,
+                "supported_sound_modes": supported_sound_modes,
             },
             "advanced_audio": {
-                "night_mode": self.night_mode,
-                "bass_mode": self.bass_mode,
-                "voice_amplifier": self.voice_amplifier,
+                "night_mode": night_mode,
+                "bass_mode": bass_mode,
+                "voice_amplifier": voice_amplifier,
             },
             "equalizer": {
-                "active_preset": self.active_equalizer_preset,
-                "supported_presets": self.supported_equalizer_presets,
-                "action": self.equalizer_action,
-                "bands": self.equalizer_bands,
+                "active_preset": active_eq_preset,
+                "supported_presets": supported_eq_presets,
+                "action": equalizer_action,
+                "bands": equalizer_bands,
             },
             "media": {
                 "media_title": self.media_title,
@@ -516,5 +914,40 @@ class SoundbarDevice:
                 "media_cover_url": self.media_coverart_url,
                 "media_duration": self.media_duration,
                 "media_position": self.media_position,
+                "media_cover_updated": media_cover_updated,
+            },
+            "capabilities": {
+                "available_main_capabilities": available_capabilities,
+                "feature_flags": {
+                    "enable_soundmode": self.__enable_soundmode,
+                    "enable_advanced_audio": self.__enable_advanced_audio,
+                    "enable_woofer": self.__enable_woofer,
+                    "enable_eq": self.__enable_eq,
+                },
+            },
+            "timestamps": {
+                "switch": self._get_status_timestamp(Capability.SWITCH, "switch"),
+                "volume": self._get_status_timestamp(Capability.AUDIO_VOLUME, "volume"),
+                "mute": self._get_status_timestamp(Capability.AUDIO_MUTE, "mute"),
+                "playback_status": self._get_status_timestamp(
+                    Capability.MEDIA_PLAYBACK,
+                    "playbackStatus",
+                ),
+                "audio_track": self._get_status_timestamp(
+                    Capability.AUDIO_TRACK_DATA,
+                    "audioTrackData",
+                ),
+                "media_position": self._get_status_timestamp(
+                    Capability.AUDIO_TRACK_DATA,
+                    "elapsedTime",
+                ),
+                "media_duration": self._get_status_timestamp(
+                    Capability.AUDIO_TRACK_DATA,
+                    "totalTime",
+                ),
+            },
+            "api_backoff": {
+                "status_retry_until": status_retry_until,
+                "execute_retry_until": execute_retry_until,
             },
         }

--- a/custom_components/samsung_soundbar/application_credentials.py
+++ b/custom_components/samsung_soundbar/application_credentials.py
@@ -1,0 +1,15 @@
+"""Application credentials platform for Samsung Soundbar."""
+
+from homeassistant.components.application_credentials import AuthorizationServer
+from homeassistant.core import HomeAssistant
+
+SMARTTHINGS_AUTHORIZE_URL = "https://api.smartthings.com/oauth/authorize"
+SMARTTHINGS_TOKEN_URL = "https://api.smartthings.com/oauth/token"
+
+
+async def async_get_authorization_server(hass: HomeAssistant) -> AuthorizationServer:
+    """Return the SmartThings OAuth2 authorization server."""
+    return AuthorizationServer(
+        authorize_url=SMARTTHINGS_AUTHORIZE_URL,
+        token_url=SMARTTHINGS_TOKEN_URL,
+    )

--- a/custom_components/samsung_soundbar/config_flow.py
+++ b/custom_components/samsung_soundbar/config_flow.py
@@ -13,7 +13,6 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from pysmartthings import APIResponseError
 from voluptuous import All, Range
 
 from .const import (
@@ -48,7 +47,7 @@ async def validate_input(api: pysmartthings.SmartThings, device_id: str):
     """Validate that the selected device exists and can be loaded."""
     try:
         return await api.get_device(device_id)
-    except APIResponseError as exc:
+    except Exception as exc:  # pragma: no cover - runtime API errors
         _LOGGER.error("[Samsung Soundbar] ERROR: %s", str(exc))
         raise ValueError from exc
 

--- a/custom_components/samsung_soundbar/config_flow.py
+++ b/custom_components/samsung_soundbar/config_flow.py
@@ -1,15 +1,22 @@
+"""Config flow for Samsung Soundbar integration."""
+
+from __future__ import annotations
+
 import logging
 from typing import Any
 
 import pysmartthings
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from pysmartthings import APIResponseError
 from voluptuous import All, Range
 
 from .const import (
-    CONF_ENTRY_API_KEY,
     CONF_ENTRY_DEVICE_ID,
     CONF_ENTRY_DEVICE_NAME,
     CONF_ENTRY_MAX_VOLUME,
@@ -22,120 +29,208 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_OPTIONS = {
+    CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES: False,
+    CONF_ENTRY_SETTINGS_EQ_SELECTOR: False,
+    CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR: False,
+    CONF_ENTRY_SETTINGS_WOOFER_NUMBER: False,
+    CONF_ENTRY_MAX_VOLUME: 100,
+}
 
-async def validate_input(api, device_id: str):
+
+async def validate_input(api: pysmartthings.SmartThings, device_id: str):
+    """Validate that the selected device exists and can be loaded."""
     try:
         return await api.device(device_id)
-    except APIResponseError as excp:
-        _LOGGER.error("[Samsung Soundbar] ERROR: %s", str(excp))
-        raise ValueError
+    except APIResponseError as exc:
+        _LOGGER.error("[Samsung Soundbar] ERROR: %s", str(exc))
+        raise ValueError from exc
 
 
-class ExampleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    async def async_step_user(self, user_input=None):
-        if user_input is not None:
-            self.user_input = user_input
-            return await self.async_step_device()
+class SamsungSoundbarFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain=DOMAIN):
+    """Handle a Samsung Soundbar OAuth2 config flow."""
 
-        return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_ENTRY_API_KEY): str,
-                    vol.Required(CONF_ENTRY_DEVICE_ID): str,
-                    vol.Required(CONF_ENTRY_DEVICE_NAME): str,
-                    vol.Required(CONF_ENTRY_MAX_VOLUME, default=100): All(
-                        int, Range(min=1, max=100)
-                    ),
-                }
-            ),
+    VERSION = 1
+
+    reauth_entry: config_entries.ConfigEntry | None = None
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._oauth_data: dict[str, Any] | None = None
+        self._available_devices: dict[str, str] = {}
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry):
+        """Return options flow for this handler."""
+        return SamsungSoundbarOptionsFlowHandler(config_entry)
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Start OAuth flow."""
+        return await super().async_step_user(user_input)
+
+    async def async_oauth_create_entry(self, data: dict[str, Any]) -> FlowResult:
+        """Create config entry after OAuth has completed."""
+        self._oauth_data = data
+
+        session = config_entry_oauth2_flow.OAuth2Session(self.hass, self.flow_impl, data)
+        await session.async_ensure_token_valid()
+        api = pysmartthings.SmartThings(
+            async_get_clientsession(self.hass), session.token[CONF_ACCESS_TOKEN]
         )
 
-    async def async_step_device(self, user_input: dict[str, any] | None = None):
+        try:
+            devices = await api.devices()
+        except Exception as exc:  # pragma: no cover - defensive for runtime API errors
+            _LOGGER.error("Unable to fetch SmartThings devices during setup: %s", exc)
+            return self.async_abort(reason="fetch_failed")
+
+        self._available_devices = {
+            device.device_id: getattr(device, "label", None) or device.device_id
+            for device in devices
+        }
+
+        if self.reauth_entry:
+            return self.async_update_reload_and_abort(
+                self.reauth_entry,
+                data={**self.reauth_entry.data, **data},
+                reason="reauth_successful",
+            )
+
+        if not self._available_devices:
+            return self.async_abort(reason="no_devices")
+
+        return await self.async_step_device()
+
+    async def async_step_device(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Pick a SmartThings device and create entry."""
         if user_input is not None:
-            self.user_input.update(user_input)
+            assert self._oauth_data is not None
+
+            session = config_entry_oauth2_flow.OAuth2Session(
+                self.hass, self.flow_impl, self._oauth_data
+            )
+            await session.async_ensure_token_valid()
+            api = pysmartthings.SmartThings(
+                async_get_clientsession(self.hass), session.token[CONF_ACCESS_TOKEN]
+            )
 
             try:
-                session = async_get_clientsession(self.hass)
-                api = pysmartthings.SmartThings(
-                    session, self.user_input.get(CONF_ENTRY_API_KEY)
-                )
-                device = await validate_input(
-                    api, self.user_input.get(CONF_ENTRY_DEVICE_ID)
-                )
-                _LOGGER.debug(
-                    f"Successfully validated Input, Creating entry with title {DOMAIN} and data {user_input}"
-                )
-            except Exception as excp:
-                _LOGGER.error(f"The ConfigFlow triggered an exception {excp}")
+                await validate_input(api, user_input[CONF_ENTRY_DEVICE_ID])
+            except Exception:
                 return self.async_abort(reason="fetch_failed")
-            return self.async_create_entry(title=DOMAIN, data=self.user_input)
+
+            await self.async_set_unique_id(user_input[CONF_ENTRY_DEVICE_ID])
+            self._abort_if_unique_id_configured()
+
+            entry_data = {
+                **self._oauth_data,
+                CONF_ENTRY_DEVICE_ID: user_input[CONF_ENTRY_DEVICE_ID],
+                CONF_ENTRY_DEVICE_NAME: user_input[CONF_ENTRY_DEVICE_NAME],
+            }
+            return self.async_create_entry(
+                title=user_input[CONF_ENTRY_DEVICE_NAME],
+                data=entry_data,
+                options=DEFAULT_OPTIONS,
+            )
+
+        default_device_id = next(iter(self._available_devices), None)
+        default_name = self._available_devices.get(default_device_id, DOMAIN)
 
         return self.async_show_form(
             step_id="device",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES): bool,
-                    vol.Required(CONF_ENTRY_SETTINGS_EQ_SELECTOR): bool,
-                    vol.Required(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR): bool,
-                    vol.Required(CONF_ENTRY_SETTINGS_WOOFER_NUMBER): bool,
+                    vol.Required(
+                        CONF_ENTRY_DEVICE_ID,
+                        default=default_device_id,
+                    ): vol.In(self._available_devices),
+                    vol.Required(CONF_ENTRY_DEVICE_NAME, default=default_name): str,
                 }
             ),
         )
 
-    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None):
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> FlowResult:
+        """Handle reauth request."""
+        self.reauth_entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm reauthentication and restart OAuth flow."""
+        if user_input is None:
+            return self.async_show_form(step_id="reauth_confirm")
+
+        return await self.async_step_user()
+
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle a reconfiguration flow initialized by the user."""
-        self.config_entry = self.hass.config_entries.async_get_entry(
-            self.context["entry_id"]
-        )
-        return await self.async_step_reconfigure_confirm()
+        self.config_entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        return await self.async_step_reconfigure_confirm(user_input)
 
     async def async_step_reconfigure_confirm(
         self, user_input: dict[str, Any] | None = None
-    ):
-        """Handle a reconfiguration flow initialized by the user."""
-        errors: dict[str, str] = {}
+    ) -> FlowResult:
+        """Handle user-controlled feature toggles/max volume updates."""
         assert self.config_entry
 
         if user_input is not None:
             return self.async_update_reload_and_abort(
                 self.config_entry,
-                data={**self.config_entry.data, **user_input},
+                options={**self.config_entry.options, **user_input},
                 reason="reconfigure_successful",
             )
 
         return self.async_show_form(
             step_id="reconfigure_confirm",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES,
-                        default=self.config_entry.data.get(
-                            CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES
-                        ),
-                    ): bool,
-                    vol.Required(
-                        CONF_ENTRY_SETTINGS_EQ_SELECTOR,
-                        default=self.config_entry.data.get(
-                            CONF_ENTRY_SETTINGS_EQ_SELECTOR
-                        ),
-                    ): bool,
-                    vol.Required(
-                        CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR,
-                        default=self.config_entry.data.get(
-                            CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR
-                        ),
-                    ): bool,
-                    vol.Required(
-                        CONF_ENTRY_SETTINGS_WOOFER_NUMBER,
-                        default=self.config_entry.data.get(
-                            CONF_ENTRY_SETTINGS_WOOFER_NUMBER
-                        ),
-                    ): bool,
-                    vol.Required(CONF_ENTRY_MAX_VOLUME, default=100): All(
-                        int, Range(min=1, max=100)
-                    ),
-                }
-            ),
-            errors=errors,
+            data_schema=_options_schema(self.config_entry.options),
         )
+
+
+class SamsungSoundbarOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Samsung Soundbar options flow."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title="",
+                data={**self.config_entry.options, **user_input},
+            )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=_options_schema(self.config_entry.options),
+        )
+
+
+def _options_schema(options: dict[str, Any]) -> vol.Schema:
+    merged_options = {**DEFAULT_OPTIONS, **options}
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES,
+                default=merged_options[CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES],
+            ): bool,
+            vol.Required(
+                CONF_ENTRY_SETTINGS_EQ_SELECTOR,
+                default=merged_options[CONF_ENTRY_SETTINGS_EQ_SELECTOR],
+            ): bool,
+            vol.Required(
+                CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR,
+                default=merged_options[CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR],
+            ): bool,
+            vol.Required(
+                CONF_ENTRY_SETTINGS_WOOFER_NUMBER,
+                default=merged_options[CONF_ENTRY_SETTINGS_WOOFER_NUMBER],
+            ): bool,
+            vol.Required(
+                CONF_ENTRY_MAX_VOLUME,
+                default=merged_options[CONF_ENTRY_MAX_VOLUME],
+            ): All(int, Range(min=1, max=100)),
+        }
+    )

--- a/custom_components/samsung_soundbar/config_flow.py
+++ b/custom_components/samsung_soundbar/config_flow.py
@@ -38,10 +38,16 @@ DEFAULT_OPTIONS = {
 }
 
 
+def _get_authenticated_client(hass, token: str) -> pysmartthings.SmartThings:
+    api = pysmartthings.SmartThings(session=async_get_clientsession(hass))
+    api.authenticate(token)
+    return api
+
+
 async def validate_input(api: pysmartthings.SmartThings, device_id: str):
     """Validate that the selected device exists and can be loaded."""
     try:
-        return await api.device(device_id)
+        return await api.get_device(device_id)
     except APIResponseError as exc:
         _LOGGER.error("[Samsung Soundbar] ERROR: %s", str(exc))
         raise ValueError from exc
@@ -75,12 +81,10 @@ class SamsungSoundbarFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHand
 
         session = config_entry_oauth2_flow.OAuth2Session(self.hass, self.flow_impl, data)
         await session.async_ensure_token_valid()
-        api = pysmartthings.SmartThings(
-            async_get_clientsession(self.hass), session.token[CONF_ACCESS_TOKEN]
-        )
+        api = _get_authenticated_client(self.hass, session.token[CONF_ACCESS_TOKEN])
 
         try:
-            devices = await api.devices()
+            devices = await api.get_devices()
         except Exception as exc:  # pragma: no cover - defensive for runtime API errors
             _LOGGER.error("Unable to fetch SmartThings devices during setup: %s", exc)
             return self.async_abort(reason="fetch_failed")
@@ -111,9 +115,7 @@ class SamsungSoundbarFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHand
                 self.hass, self.flow_impl, self._oauth_data
             )
             await session.async_ensure_token_valid()
-            api = pysmartthings.SmartThings(
-                async_get_clientsession(self.hass), session.token[CONF_ACCESS_TOKEN]
-            )
+            api = _get_authenticated_client(self.hass, session.token[CONF_ACCESS_TOKEN])
 
             try:
                 await validate_input(api, user_input[CONF_ENTRY_DEVICE_ID])

--- a/custom_components/samsung_soundbar/const.py
+++ b/custom_components/samsung_soundbar/const.py
@@ -5,7 +5,6 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 
 DOMAIN = "samsung_soundbar"
 CONF_CLOUD_INTEGRATION = "cloud_integration"
-CONF_ENTRY_API_KEY = "api_key"
 CONF_ENTRY_DEVICE_ID = "device_id"
 CONF_ENTRY_DEVICE_NAME = "device_name"
 CONF_ENTRY_MAX_VOLUME = "device_volume"

--- a/custom_components/samsung_soundbar/manifest.json
+++ b/custom_components/samsung_soundbar/manifest.json
@@ -1,12 +1,19 @@
 {
   "domain": "samsung_soundbar",
   "name": "Samsung Soundbar",
-  "codeowners": ["@samuelspagl"],
+  "codeowners": [
+    "@samuelspagl"
+  ],
   "config_flow": true,
   "documentation": "https://www.example.com",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/samuelspagl/ha_samsung_soundbar/issues",
-  "requirements": ["pysmartthings"],
-  "version": "0.4.0"
+  "requirements": [
+    "pysmartthings"
+  ],
+  "version": "0.4.0",
+  "dependencies": [
+    "application_credentials"
+  ]
 }

--- a/custom_components/samsung_soundbar/manifest.json
+++ b/custom_components/samsung_soundbar/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/samuelspagl/ha_samsung_soundbar/issues",
   "requirements": [
-    "pysmartthings"
+    "pysmartthings==3.5.2"
   ],
   "version": "0.4.0",
   "dependencies": [

--- a/custom_components/samsung_soundbar/manifest.json
+++ b/custom_components/samsung_soundbar/manifest.json
@@ -12,7 +12,7 @@
   "requirements": [
     "pysmartthings==3.5.2"
   ],
-  "version": "0.4.0",
+  "version": "0.6.0",
   "dependencies": [
     "application_credentials"
   ]

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -14,10 +14,7 @@ import voluptuous as vol
 from .api_extension.SoundbarDevice import SoundbarDevice
 from .api_extension.const import SpeakerIdentifier, RearSpeakerMode
 from .const import (
-    CONF_ENTRY_API_KEY,
     CONF_ENTRY_DEVICE_ID,
-    CONF_ENTRY_DEVICE_NAME,
-    CONF_ENTRY_MAX_VOLUME,
     DOMAIN,
 )
 from .models import DeviceConfig

--- a/custom_components/samsung_soundbar/number.py
+++ b/custom_components/samsung_soundbar/number.py
@@ -23,7 +23,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         device = device_config.device
         if device.device_id == config_entry.data.get(
             CONF_ENTRY_DEVICE_ID
-        ) and config_entry.data.get(CONF_ENTRY_SETTINGS_WOOFER_NUMBER):
+        ) and config_entry.options.get(CONF_ENTRY_SETTINGS_WOOFER_NUMBER, False):
             entities.append(
                 SoundbarWooferNumberEntity(
                     device,

--- a/custom_components/samsung_soundbar/select.py
+++ b/custom_components/samsung_soundbar/select.py
@@ -27,11 +27,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         device_config: DeviceConfig = domain_data.devices[key]
         device = device_config.device
         if device.device_id == config_entry.data.get(CONF_ENTRY_DEVICE_ID):
-            if config_entry.data.get(CONF_ENTRY_SETTINGS_EQ_SELECTOR):
+            if config_entry.options.get(CONF_ENTRY_SETTINGS_EQ_SELECTOR, False):
                 entities.append(
                     EqPresetSelectEntity(device, "eq_preset", "mdi:tune-vertical")
                 )
-            if config_entry.data.get(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR):
+            if config_entry.options.get(CONF_ENTRY_SETTINGS_SOUNDMODE_SELECTOR, False):
                 entities.append(
                     SoundModeSelectEntity(
                         device, "sound_mode_preset", "mdi:surround-sound"

--- a/custom_components/samsung_soundbar/switch.py
+++ b/custom_components/samsung_soundbar/switch.py
@@ -22,7 +22,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         device_config: DeviceConfig = domain_data.devices[key]
         device = device_config.device
         if device.device_id == config_entry.data.get(CONF_ENTRY_DEVICE_ID):
-            if config_entry.data.get(CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES):
+            if config_entry.options.get(CONF_ENTRY_SETTINGS_ADVANCED_AUDIO_SWITCHES, False):
                 entities.append(
                     SoundbarSwitchAdvancedAudio(
                         device,

--- a/custom_components/samsung_soundbar/translations/de.json
+++ b/custom_components/samsung_soundbar/translations/de.json
@@ -1,28 +1,20 @@
 {
-    "config":{
-        "step":{
-            "user":{
+    "config": {
+        "step": {
+            "user": {
+                "description": "Verbinde dein SmartThings-Konto, um fortzufahren.",
+                "title": "Konto verbinden"
+            },
+            "device": {
                 "data": {
-                    "api_key": "SmartThings API Token",
-                    "device_id": "Device ID",
-                    "device_name":"Device Name",
-                    "device_volume": "Max Volume (int)"
-                  },
-                  "description": "Bitte gib deine Daten ein.",
-                  "title": "Authentifizierung"
-            },
-            "device":{
-                "data" : {
-                    "settings_advanced_audio": "'Advanced Audio switches' aktivieren (NightMode, BassMode, VoiceEnhancer)",
-                    "settings_eq": "'EQ selector' aktivieren",
-                    "settings_soundmode": "'Soundmode selector' aktivieren",
-                    "settings_woofer": "'Subwoofer Entität' aktivieren"
+                    "device_id": "Gerät",
+                    "device_name": "Gerätename"
                 },
-                "description": "Einige Soundbars haben verschiedene Featuresets. Wähle bitte aus welche Features von deiner Soundbar supported werden (einsehbar in der SmartThings App).",
-                "title": "Geräte Einstellungen"
+                "description": "Wähle die SmartThings-Soundbar aus, die du steuern möchtest.",
+                "title": "Gerät auswählen"
             },
-            "reconfigure_confirm":{
-                "data" : {
+            "reconfigure_confirm": {
+                "data": {
                     "settings_advanced_audio": "'Advanced Audio switches' aktivieren (NightMode, BassMode, VoiceEnhancer)",
                     "settings_eq": "'EQ selector' aktivieren",
                     "settings_soundmode": "'Soundmode selector' aktivieren",
@@ -31,7 +23,15 @@
                 },
                 "description": "Einige Soundbars haben verschiedene Featuresets. Wähle bitte aus welche Features von deiner Soundbar supported werden (einsehbar in der SmartThings App).",
                 "title": "Geräte Einstellungen"
+            },
+            "reauth_confirm": {
+                "description": "Verbinde dein SmartThings-Konto erneut, um abgelaufene Zugangsdaten zu aktualisieren.",
+                "title": "Konto erneut verbinden"
             }
+        },
+        "abort": {
+            "fetch_failed": "Verbindung zu SmartThings fehlgeschlagen. Bitte versuche es erneut.",
+            "no_devices": "Für dieses Konto wurden keine SmartThings-Geräte gefunden."
         }
     },
     "selector": {
@@ -59,56 +59,56 @@
                 "Front": "Front"
             }
         }
-  },
-  "services":{
-    "select_soundmode":{
-        "name": "SoundMode auswählen",
-        "description": "Wähle hier zwischen, 'Standard', 'Surround', 'Game' und 'Adaptive Sound'."
     },
-    "set_woofer_level":{
-        "name": "Subwoofer Level setzen",
-        "description": "Verändere die Lautstärke deines Subwoofers.",
-        "fields":{
-            "level":{
-                "name": "Volume Level",
-                "description": "Subwoofer Level, von -12 bis +6"
+    "services": {
+        "select_soundmode": {
+            "name": "SoundMode auswählen",
+            "description": "Wähle hier zwischen, 'Standard', 'Surround', 'Game' und 'Adaptive Sound'."
+        },
+        "set_woofer_level": {
+            "name": "Subwoofer Level setzen",
+            "description": "Verändere die Lautstärke deines Subwoofers.",
+            "fields": {
+                "level": {
+                    "name": "Volume Level",
+                    "description": "Subwoofer Level, von -12 bis +6"
+                }
             }
-        }
-    },
-    "set_night_mode":{
-        "name": "Nachtmodus setzen",
-        "description": "Schalte den 'Nachtmodus' an / aus.",
-        "fields":{
-            "enabled":{
-                "name": "An / ausschalten",
-                "description": "Siehe Name."
+        },
+        "set_night_mode": {
+            "name": "Nachtmodus setzen",
+            "description": "Schalte den 'Nachtmodus' an / aus.",
+            "fields": {
+                "enabled": {
+                    "name": "An / ausschalten",
+                    "description": "Siehe Name."
+                }
             }
-        }
-    },
-    "set_bass_enhancer":{
-        "name": "Bassmodus setzen",
-        "description": "Schalte den 'Bassmodus' an / aus.",
-        "fields":{
-            "enabled":{
-                "name": "An / ausschalten",
-                "description": "Siehe Name."
+        },
+        "set_bass_enhancer": {
+            "name": "Bassmodus setzen",
+            "description": "Schalte den 'Bassmodus' an / aus.",
+            "fields": {
+                "enabled": {
+                    "name": "An / ausschalten",
+                    "description": "Siehe Name."
+                }
             }
-        }
-    },
-    "set_voice_enhancer":{
-        "name": "Stimmenverbesserer setzen",
-        "description": "Schalte den 'Stimmenverbesserer' an / aus.",
-        "fields":{
-            "enabled":{
-                "name": "An / ausschalten",
-                "description": "Siehe Name."
+        },
+        "set_voice_enhancer": {
+            "name": "Stimmenverbesserer setzen",
+            "description": "Schalte den 'Stimmenverbesserer' an / aus.",
+            "fields": {
+                "enabled": {
+                    "name": "An / ausschalten",
+                    "description": "Siehe Name."
+                }
             }
-        }
-    },
-    "set_speaker_level":{
-        "name": "Lautsprecher level verändern",
-        "description": "Verändere die Lautstärke der einzelnen Lautsprecher",
-        "fields":{
+        },
+        "set_speaker_level": {
+            "name": "Lautsprecher level verändern",
+            "description": "Verändere die Lautstärke der einzelnen Lautsprecher",
+            "fields": {
                 "speaker_identifier": {
                     "name": "Lautsprecher",
                     "description": "Auszuwählender Lautsprecher"
@@ -118,36 +118,51 @@
                     "description": "Lautstärke Level zwischen -6 und 6."
                 }
             }
-    },
-    "set_rear_speaker_mode":{
-        "name": "Modus der hinteren Lautsprecher setzen",
-        "description": "Nutze deine Rücklautsprecher, als 'Vorder-' oder 'Rücklautsprecher'.",
-        "fields":{
+        },
+        "set_rear_speaker_mode": {
+            "name": "Modus der hinteren Lautsprecher setzen",
+            "description": "Nutze deine Rücklautsprecher, als 'Vorder-' oder 'Rücklautsprecher'.",
+            "fields": {
                 "speaker_mode": {
                     "name": "Lautsprecher Modus",
                     "description": "Nutze den Lautsprecher als Front oder Rear Speaker."
                 }
             }
-    },
-    "set_active_voice_amplifier":{
-        "name": "Stimmenverstärker setzen",
-        "description": "Schalte den 'Stimmenverstärker' an / aus.",
-        "fields":{
-            "enabled":{
-                "name": "An / ausschalten",
-                "description": "Siehe Name."
+        },
+        "set_active_voice_amplifier": {
+            "name": "Stimmenverstärker setzen",
+            "description": "Schalte den 'Stimmenverstärker' an / aus.",
+            "fields": {
+                "enabled": {
+                    "name": "An / ausschalten",
+                    "description": "Siehe Name."
+                }
+            }
+        },
+        "set_space_fit_sound": {
+            "name": "SpaceFitSound setzen",
+            "description": "Schalte den 'SpaceFitSound' an / aus.",
+            "fields": {
+                "enabled": {
+                    "name": "An / ausschalten",
+                    "description": "Siehe Name."
+                }
             }
         }
     },
-    "set_space_fit_sound":{
-        "name": "SpaceFitSound setzen",
-        "description": "Schalte den 'SpaceFitSound' an / aus.",
-        "fields":{
-            "enabled":{
-                "name": "An / ausschalten",
-                "description": "Siehe Name."
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "settings_advanced_audio": "'Advanced Audio switches' aktivieren (NightMode, BassMode, VoiceEnhancer)",
+                    "settings_eq": "'EQ selector' aktivieren",
+                    "settings_soundmode": "'Soundmode selector' aktivieren",
+                    "settings_woofer": "'Subwoofer Entität' aktivieren",
+                    "device_volume": "Max Volume (int)"
+                },
+                "description": "Einige Soundbars haben verschiedene Featuresets. Wähle bitte aus welche Features von deiner Soundbar supported werden (einsehbar in der SmartThings App).",
+                "title": "Geräte Einstellungen"
             }
         }
     }
-  }
 }

--- a/custom_components/samsung_soundbar/translations/en.json
+++ b/custom_components/samsung_soundbar/translations/en.json
@@ -2,24 +2,16 @@
     "config": {
         "step": {
             "user": {
-                "data": {
-                    "api_key": "SmartThings API Token",
-                    "device_id": "Device ID",
-                    "device_name": "Device Name",
-                    "device_volume": "Max Volume (int)"
-                },
-                "description": "Please enter your credentials.",
-                "title": "Authentication"
+                "description": "Link your SmartThings account to continue.",
+                "title": "Connect Account"
             },
             "device": {
                 "data": {
-                    "settings_advanced_audio": "Enable 'Advanced Audio switches' capabilities (NightMode, BassMode, VoiceEnhancer)",
-                    "settings_eq": "Enable 'EQ selector' capabilities",
-                    "settings_soundmode": "Enable 'Soundmode selector' capabilities",
-                    "settings_woofer": "Enable 'Woofer number' capability"
+                    "device_id": "Device",
+                    "device_name": "Device Name"
                 },
-                "description": "Some soundbars have a different featureset than others. Please the features supported by your soundbar (visible in the SmartThings App).",
-                "title": "Device Settings"
+                "description": "Choose the SmartThings soundbar you want to control.",
+                "title": "Select Device"
             },
             "reconfigure_confirm": {
                 "data": {
@@ -29,9 +21,17 @@
                     "settings_woofer": "Enable 'Woofer number' capability",
                     "device_volume": "Max Volume (int)"
                 },
-                "description": "Some soundbars have a different featureset than others. Please the features supported by your soundbar (visible in the SmartThings App).",
+                "description": "Some soundbars have a different featureset than others. Please select the features supported by your soundbar (visible in the SmartThings App).",
                 "title": "Device Settings"
+            },
+            "reauth_confirm": {
+                "description": "Reconnect your SmartThings account to refresh expired credentials.",
+                "title": "Reconnect Account"
             }
+        },
+        "abort": {
+            "fetch_failed": "Could not connect to SmartThings. Please try again.",
+            "no_devices": "No SmartThings devices were found for this account."
         }
     },
     "selector": {
@@ -108,7 +108,7 @@
         "set_speaker_level": {
             "name": "Change Speaker Level",
             "description": "Change the volume of individual speakers.",
-            "fields":{
+            "fields": {
                 "speaker_identifier": {
                     "name": "Speaker Identifier",
                     "description": "Identifier of the speaker."
@@ -122,7 +122,7 @@
         "set_rear_speaker_mode": {
             "name": "Set Rear Speaker Mode",
             "description": "Use your rear speakers as 'Front' or 'Rear' speakers.",
-            "fields":{
+            "fields": {
                 "speaker_mode": {
                     "name": "Speaker mode",
                     "description": "Weather the speaker are used as rear / front speakers."
@@ -147,6 +147,21 @@
                     "name": "On/Off",
                     "description": "See name."
                 }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "settings_advanced_audio": "Enable 'Advanced Audio switches' capabilities (NightMode, BassMode, VoiceEnhancer)",
+                    "settings_eq": "Enable 'EQ selector' capabilities",
+                    "settings_soundmode": "Enable 'Soundmode selector' capabilities",
+                    "settings_woofer": "Enable 'Woofer number' capability",
+                    "device_volume": "Max Volume (int)"
+                },
+                "description": "Some soundbars have a different featureset than others. Please select the features supported by your soundbar (visible in the SmartThings App).",
+                "title": "Device Settings"
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Replace manual API-key handling with Home Assistant OAuth2 Application Credentials so SmartThings OAuth implementations are discoverable and token lifecycle is handled by HA.
- Align the device layer with the SmartThings client patterns so API calls, execute-status polling, and rate-limit backoff are handled consistently by the integration.
- Move per-device feature toggles out of initial auth into options so account linking (OAuth) is separated from device configuration.

### Description
- Added `application_credentials.py` that exposes SmartThings `authorize`/`token` endpoints and wired `application_credentials` as a manifest dependency so HA can discover the OAuth implementation.
- Reworked the config flow to `AbstractOAuth2FlowHandler` (OAuth2-based), implemented `async_oauth_create_entry`, device selection after OAuth, `async_step_reauth`, and an options flow (`SamsungSoundbarOptionsFlowHandler`) with `DEFAULT_OPTIONS` for feature flags and max volume.
- Replaced the previous `SoundbarDevice` wrapper with a SmartThings-client-driven implementation in `api_extension/SoundbarDevice.py` that: reads raw component status data, issues capability/command calls via the SmartThings client, implements execute-status polling with timeout and TooManyRequest backoff handling, and no longer performs per-device token refreshs itself.
- Updated runtime setup (`__init__.py`) to obtain an OAuth access token via HA `OAuth2Session`, construct the `SmartThings` client with that token, pass the client into `SoundbarDevice`, persist `entry.options` (feature flags/max volume), and reload entries on updates.
- Updated platform modules (`media_player.py`, `select.py`, `switch.py`, `number.py`, etc.) to read feature flags from `config_entry.options` instead of `config_entry.data`, and refreshed translations (`translations/en.json`, `translations/de.json`) to remove API-key prompts and add OAuth/reauth and options-flow strings.

### Testing
- Ran `python -m compileall custom_components/samsung_soundbar` and the integration modules compiled successfully.
- Validated translation JSONs with `python -m json.tool custom_components/samsung_soundbar/translations/en.json` which parsed successfully.
- Validated translation JSONs with `python -m json.tool custom_components/samsung_soundbar/translations/de.json` which parsed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69906f164f10832ea2075d0961198a01)